### PR TITLE
NN-1441 'In today' results page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,14 +36,9 @@ import PaymentReasonContainer from './ModalProvider/PaymentReasonModal/PaymentRe
 import links from './links'
 import MovementsInContainer from './MovementsIn/MovementsInContainer'
 import MovementsOutContainer from './MovementsOut/MovementsOutContainer'
+import routePaths from './routePaths'
 
 const axios = require('axios')
-
-const routePaths = {
-  establishmentRoll: '/establishmentroll',
-  inToday: '/establishmentroll/in-today',
-  outToday: '/establishmentroll/out-today',
-}
 
 class App extends React.Component {
   async componentWillMount() {
@@ -447,5 +442,5 @@ const AppContainer = connect(
   mapDispatchToProps
 )(App)
 
-export { App, AppContainer, routePaths }
+export { App, AppContainer }
 export default App

--- a/src/EstablishmentRoll/EstablishmentRollBlock.js
+++ b/src/EstablishmentRoll/EstablishmentRollBlock.js
@@ -4,19 +4,23 @@ import classNames from 'classnames'
 import { withRouter } from 'react-router'
 import { Link } from 'react-router-dom'
 import './EstablishmentRollBlock.scss'
-import { routePaths } from '../App'
+import routePaths from '../routePaths'
 
+const pathsToStatisticsDetailsPages = new Map([['In today', routePaths.inToday], ['Out today', routePaths.outToday]])
 export class EstablishmentRollBlock extends Component {
-  linkedFigures = new Map([['In today', routePaths.inToday], ['Out today', routePaths.outToday]])
-
-  addLink(label, content) {
-    return this.linkedFigures.has(label) ? <Link to={this.linkedFigures.get(label)}>{content}</Link> : content
-  }
+  addLinkToDetailsPage = (label, content) =>
+    pathsToStatisticsDetailsPages.has(label) ? (
+      <Link to={pathsToStatisticsDetailsPages.get(label)} className="link">
+        {content}
+      </Link>
+    ) : (
+      content
+    )
 
   renderBlockFigure = (label, value) => (
     <div className="block-figure">
       <label className="block-figure__label">{label}</label>
-      {this.addLink(label, <span className="block-figure__value">{value}</span>)}
+      {this.addLinkToDetailsPage(label, <span className="block-figure__value">{value}</span>)}
     </div>
   )
 

--- a/src/EstablishmentRoll/EstablishmentRollBlock.test.js
+++ b/src/EstablishmentRoll/EstablishmentRollBlock.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 import { EstablishmentRollBlock } from './EstablishmentRollBlock'
-import { routePaths } from '../App'
+import routePaths from '../routePaths'
 
 describe('<EstablishmentRollBlock />', () => {
   const props = {

--- a/src/routePaths.js
+++ b/src/routePaths.js
@@ -1,0 +1,5 @@
+export default {
+  establishmentRoll: '/establishmentroll',
+  inToday: '/establishmentroll/in-today',
+  outToday: '/establishmentroll/out-today',
+}


### PR DESCRIPTION
Add 'link' style to establishmentroll clickable stats. 
Move map of statistics names to paths of details pages outside EstablishmentRollBlock and move export of constants to a separate file to fix circular imports problem.