### PR TITLE
NN-1553 in reception results page fixes

### DIFF
--- a/backend/controllers/movementsService.js
+++ b/backend/controllers/movementsService.js
@@ -16,7 +16,7 @@ const movementsServiceFactory = (elite2Api, systemOauthClient) => {
   const getRecentMovements = async offenderNumbers => {
     const systemContext = await systemOauthClient.getClientCredentialsTokens()
 
-    return elite2Api.getRecentMovements(systemContext, offenderNumbers, ['TRN'])
+    return elite2Api.getRecentMovements(systemContext, offenderNumbers, [])
   }
 
   const extractOffenderNumbers = movements => movements.map(m => m.offenderNo)

--- a/backend/tests/movementsService.test.js
+++ b/backend/tests/movementsService.test.js
@@ -157,7 +157,7 @@ describe('Movement service', () => {
 
       await movementsServiceFactory(eliteApi, oauthClient).getOffendersInReception(context, agency)
 
-      expect(eliteApi.getRecentMovements).toHaveBeenCalledWith(systemContext, offenderNumbers, ['TRN'])
+      expect(eliteApi.getRecentMovements).toHaveBeenCalledWith(systemContext, offenderNumbers, [])
     })
 
     it('should populate offenders in reception with the from agency', async () => {

--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/mockapis/Elite2Api.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/mockapis/Elite2Api.groovy
@@ -465,7 +465,7 @@ class Elite2Api extends WireMockRule {
 
     def stubRecentMovements(movements = []) {
         this.stubFor(
-                post("/api/movements/offenders?movementTypes=TRN")
+                post("/api/movements/offenders")
                         .willReturn(
                         aResponse()
                                 .withBody(JsonOutput.toJson(movements))

--- a/src/EstablishmentRoll/EstablishmentRollBlock.js
+++ b/src/EstablishmentRoll/EstablishmentRollBlock.js
@@ -13,8 +13,8 @@ const pathsToStatisticsDetailsPages = new Map([
 ])
 
 export class EstablishmentRollBlock extends Component {
-  addLinkToDetailsPage = (label, content) =>
-    pathsToStatisticsDetailsPages.has(label) ? (
+  addLinkToDetailsPage = (label, content, value) =>
+    value !== 0 && pathsToStatisticsDetailsPages.has(label) ? (
       <Link to={pathsToStatisticsDetailsPages.get(label)} className="link">
         {content}
       </Link>
@@ -25,7 +25,7 @@ export class EstablishmentRollBlock extends Component {
   renderBlockFigure = (label, value) => (
     <div className="block-figure">
       <label className="block-figure__label">{label}</label>
-      {this.addLinkToDetailsPage(label, <span className="block-figure__value">{value}</span>)}
+      {this.addLinkToDetailsPage(label, <span className="block-figure__value">{value}</span>, value)}
     </div>
   )
 


### PR DESCRIPTION
  - Remove link from establishment roll page when the result count is zero
  - Return all recent movements regardless of movement type