### PR TITLE
NN-1632 Adding viewport and sizing components.

### DIFF
--- a/html-template/index.html
+++ b/html-template/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="theme-color" content="#000000">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
   <!--
     manifest.json provides metadata used when your web app is added to the
     homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/

--- a/html-template/index.html
+++ b/html-template/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="theme-color" content="#000000">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <!--
     manifest.json provides metadata used when your web app is added to the
     homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/

--- a/src/Components/Sizing/Sizing.js
+++ b/src/Components/Sizing/Sizing.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components'
+import { MEDIA_QUERIES } from '@govuk-react/constants'
+
+export const MobileOnly = styled.div`
+  display: block;
+  ${MEDIA_QUERIES.DESKTOP} {
+    display: none;
+  }
+`
+
+export const DesktopOnly = styled.div`
+  display: none;
+  ${MEDIA_QUERIES.DESKTOP} {
+    display: block;
+    height: 100%;
+  }
+`

--- a/src/Components/Sizing/Sizing.test.js
+++ b/src/Components/Sizing/Sizing.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import 'jest-styled-components'
 import { BREAKPOINTS } from '@govuk-react/constants'
-import { MobileOnly, DesktopOnly } from '.'
+import { MobileOnly, DesktopOnly } from './Sizing'
 
 describe('<DesktopOnly />', () => {
   it('Renders correctly at different sizes', () => {

--- a/src/Components/Sizing/index.js
+++ b/src/Components/Sizing/index.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components'
+import { MEDIA_QUERIES } from '@govuk-react/constants'
+
+export const MobileOnly = styled.div`
+  display: block;
+  ${MEDIA_QUERIES.DESKTOP} {
+    display: none;
+  }
+`
+
+export const DesktopOnly = styled.div`
+  display: none;
+  ${MEDIA_QUERIES.DESKTOP} {
+    display: block;
+    height: 100%;
+  }
+`

--- a/src/Components/Sizing/index.js
+++ b/src/Components/Sizing/index.js
@@ -1,17 +1,3 @@
-import styled from 'styled-components'
-import { MEDIA_QUERIES } from '@govuk-react/constants'
+import { DesktopOnly, MobileOnly } from './Sizing'
 
-export const MobileOnly = styled.div`
-  display: block;
-  ${MEDIA_QUERIES.DESKTOP} {
-    display: none;
-  }
-`
-
-export const DesktopOnly = styled.div`
-  display: none;
-  ${MEDIA_QUERIES.DESKTOP} {
-    display: block;
-    height: 100%;
-  }
-`
+export { DesktopOnly, MobileOnly }

--- a/src/Components/Sizing/index.test.js
+++ b/src/Components/Sizing/index.test.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import 'jest-styled-components'
+import { BREAKPOINTS } from '@govuk-react/constants'
+import { MobileOnly, DesktopOnly } from '.'
+
+describe('<DesktopOnly />', () => {
+  it('Renders correctly at different sizes', () => {
+    const elem = renderer.create(<DesktopOnly />).toJSON()
+    expect(elem).toHaveStyleRule('display', 'none')
+    expect(elem).toHaveStyleRule('display', 'block', { media: `only screen and (min-width: ${BREAKPOINTS.DESKTOP})` })
+  })
+})
+
+describe('<MobileOnly />', () => {
+  it('Renders correctly at different sizes', () => {
+    const elem = renderer.create(<MobileOnly />).toJSON()
+    expect(elem).toHaveStyleRule('display', 'block')
+    expect(elem).toHaveStyleRule('display', 'none', { media: `only screen and (min-width: ${BREAKPOINTS.DESKTOP})` })
+  })
+})


### PR DESCRIPTION
These sizing components can be used to view/hide sections based on screen size.

Uses gov-react constants with the breakpoint being 769px.

Elements smaller than this will be hidden if wrapped in DesktopOnly and only displayed if wrapped with MobileOnly.

These are not currently used but will be in follow ups.