### PR TITLE
Remove unused variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,6 @@ jobs:
              fi
 
              docker build --rm=false . \
-                 --build-arg CLIENT=hmpps \
                  --build-arg BUILD_NUMBER=$VERSION \
                  --build-arg GIT_REF=$GIT_REF \
                  --build-arg GIT_DATE=$GIT_DATE \


### PR DESCRIPTION
Currently get a warning in the docker build saying: 

```
[Warning] One or more build-args [CLIENT] were not consumed
```

e.g: https://circleci.com/gh/ministryofjustice/prisonstaffhub/3010