### PR TITLE
Moving NOTM port away from the standard port for feature tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
   },
   "scripts": {
     "start": "node $NODE_DEBUG_OPTION backend/index.js",
-    "start-feature": "PORT=3006 OAUTH_ENDPOINT_URL=http://localhost:19090/auth/ API_ENDPOINT_URL=http://localhost:18080/ node $NODE_DEBUG_OPTION backend/index.js",
+    "start-feature": "PORT=3006 OAUTH_ENDPOINT_URL=http://localhost:19090/auth/ API_ENDPOINT_URL=http://localhost:18080/ NN_ENDPOINT_URL=http://localhost:20200/ node $NODE_DEBUG_OPTION backend/index.js",
     "build": "webpack --mode=production",
     "build:analyse": "BUNDLE_ANALYSE=true yarn build",
     "test": "jest --env=jsdom",

--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/specs/AgencySelectionSpecification.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/specs/AgencySelectionSpecification.groovy
@@ -17,7 +17,7 @@ import static uk.gov.justice.digital.hmpps.prisonstaffhub.model.UserAccount.ITAG
 
 class AgencySelectionSpecification extends BrowserReportingSpec {
 
-    static final NOTM_URL = 'http://localhost:3000/'
+    static final NOTM_URL = 'http://localhost:20200/'
     @Rule
     Elite2Api elite2api = new Elite2Api()
 
@@ -25,7 +25,7 @@ class AgencySelectionSpecification extends BrowserReportingSpec {
     OauthApi oauthApi = new OauthApi()
 
     @Rule
-    public WireMockRule notmServer = new WireMockRule(3000)
+    public WireMockRule notmServer = new WireMockRule(20200)
 
     TestFixture fixture = new TestFixture(browser, elite2api, oauthApi)
 


### PR DESCRIPTION
Otherwise wiremock fails to bind to the port and fails the agency selection tests
if you happen to have NOTM running locally for development.