### PR TITLE
NN-1632 Adding All option to select box.

### DIFF
--- a/src/Adjudications/AdjudicationHistory/AdjudicationHistoryForm.js
+++ b/src/Adjudications/AdjudicationHistory/AdjudicationHistoryForm.js
@@ -76,9 +76,7 @@ export const FormFields = ({ now, errors, submitting, agencies = [], values, res
               id="establishment-select"
               value={values.establishment}
             >
-              <option value="" disabled hidden>
-                All
-              </option>
+              <option value="">All</option>
               {agencies.map(agency => (
                 <option key={agency.agencyId} value={agency.agencyId}>
                   {agency.description}

--- a/src/Adjudications/AdjudicationHistory/__snapshots__/AdjudicationHistoryForm.test.js.snap
+++ b/src/Adjudications/AdjudicationHistory/__snapshots__/AdjudicationHistoryForm.test.js.snap
@@ -46,8 +46,6 @@ exports[`Adjudication History Form should render correctly 1`] = `
                 value="MDI"
               >
                 <option
-                  disabled={true}
-                  hidden={true}
                   value=""
                 >
                   All


### PR DESCRIPTION
This previously only appeared on the first load and was then not selectable after another option was chosen,
meaing that the user had to 'clear filters' to reset it.