### PR TITLE
Nn 1921 update filters and display

### DIFF
--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/pages/IepHistory.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/pages/IepHistory.groovy
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.prisonstaffhub.pages
 import geb.Page
 
 class IepHistory  extends Page {
-    static url = '/offenders/A1234AC/iep-level'
+    static url = '/offenders/A1234AC/iep-details'
 
     static at = {
         pageTitle == 'IEP history for Norman Bates'

--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/pages/IepHistory.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/pages/IepHistory.groovy
@@ -6,7 +6,7 @@ class IepHistory  extends Page {
     static url = '/offenders/A1234AC/iep-details'
 
     static at = {
-        pageTitle == 'IEP history for Norman Bates'
+        pageTitle == 'IEP details for Norman Bates'
     }
 
     static content = {

--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/specs/IepHistorySpecification.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/specs/IepHistorySpecification.groovy
@@ -59,7 +59,7 @@ class IepHistorySpecification extends BrowserReportingSpec {
 
         breadcrumb == [['Home', NOTM_URL],
                        ['Bates, Norman', "${NOTM_URL}offenders/A1234AC/quick-look"],
-                       ['IEP level', '']]
+                       ['IEP details', '']]
 
         tableRows.size() == 4 // Including header row
 

--- a/src/Adjudications/AdjudicationHistory/__snapshots__/AdjudicationHistoryForm.test.js.snap
+++ b/src/Adjudications/AdjudicationHistory/__snapshots__/AdjudicationHistoryForm.test.js.snap
@@ -5,7 +5,7 @@ exports[`Adjudication History Form should render correctly 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="sc-chPdSV bcSAZc"
+    className="sc-chPdSV ddsHXB"
   >
     <div
       className="sc-bdVaJa gkOpjT"
@@ -17,7 +17,7 @@ exports[`Adjudication History Form should render correctly 1`] = `
           className="sc-bdVaJa gkOpjT"
         >
           <h3
-            className="sc-kGXeez lkXioC sc-fjdhpX TnkYd"
+            className="sc-kGXeez iHgsBB sc-fjdhpX TnkYd"
           >
             Filters
           </h3>
@@ -74,7 +74,7 @@ exports[`Adjudication History Form should render correctly 1`] = `
           className="sc-bdVaJa gkOpjT"
         >
           <span
-            className="sc-kpOJdX uKFLa"
+            className="sc-kpOJdX irqhhZ"
           >
             Reported date
           </span>

--- a/src/Components/FilterForm/FilterForm.styles.js
+++ b/src/Components/FilterForm/FilterForm.styles.js
@@ -14,9 +14,10 @@ export const FullWidthSelect = styled(Select)`
 `
 
 export const SearchArea = styled.div`
-  background: ${GREY_3};
+  background: #f2f2f2;
   padding: ${SPACING.SCALE_5};
-  margin-bottom: ${SPACING.SCALE_3};
+  padding-bottom: ${SPACING.SCALE_3};
+  margin-bottom: ${SPACING.SCALE_5};
 `
 
 export const LargeScreenOnlyGridCol = styled(GridCol)`
@@ -27,12 +28,12 @@ export const LargeScreenOnlyGridCol = styled(GridCol)`
   }
 `
 export const FiltersLabel = styled(H3)`
-  padding-left: ${SPACING.SCALE_2};
+  padding-left: ${SPACING.SCALE_3};
   margin-bottom: ${SPACING.SCALE_2};
   margin-top: -${SPACING.SCALE_2};
 `
 export const DateRangeLabel = styled.span`
-  padding-left: ${SPACING.SCALE_2};
+  padding-left: ${SPACING.SCALE_3};
   ${typography.font({ size: 19 })};
   font-weight: bold;
   margin-top: ${SPACING.SCALE_1};

--- a/src/IepHistory/IepHistory.js
+++ b/src/IepHistory/IepHistory.js
@@ -2,12 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import Table from '@govuk-react/table'
+import { H2 } from '@govuk-react/heading'
 import { LargeScreenOnly, SmallScreenOnly } from '../Components/sizing'
 
 const IepHistory = ({ results }) => (
   <>
+    <H2>IEP history</H2>
     <LargeScreenOnly>
-      <Table caption="IEP history" className="results">
+      <Table className="results">
         <Table.Row>
           <Table.CellHeader>Date and Time</Table.CellHeader>
           <Table.CellHeader>IEP Description</Table.CellHeader>
@@ -27,7 +29,7 @@ const IepHistory = ({ results }) => (
       </Table>
     </LargeScreenOnly>
     <SmallScreenOnly>
-      <Table caption="IEP history">
+      <Table>
         <Table.Row>
           <Table.CellHeader>Date and Time</Table.CellHeader>
           <Table.CellHeader>IEP Description</Table.CellHeader>

--- a/src/IepHistory/IepHistory.js
+++ b/src/IepHistory/IepHistory.js
@@ -11,8 +11,8 @@ const IepHistory = ({ results }) => (
     <LargeScreenOnly>
       <Table className="results">
         <Table.Row>
-          <Table.CellHeader>Date and Time</Table.CellHeader>
-          <Table.CellHeader>IEP Description</Table.CellHeader>
+          <Table.CellHeader>Date and time</Table.CellHeader>
+          <Table.CellHeader>IEP description</Table.CellHeader>
           <Table.CellHeader>Reason</Table.CellHeader>
           <Table.CellHeader>Establishment</Table.CellHeader>
           <Table.CellHeader>Staff member</Table.CellHeader>
@@ -31,8 +31,8 @@ const IepHistory = ({ results }) => (
     <SmallScreenOnly>
       <Table>
         <Table.Row>
-          <Table.CellHeader>Date and Time</Table.CellHeader>
-          <Table.CellHeader>IEP Description</Table.CellHeader>
+          <Table.CellHeader>Date and time</Table.CellHeader>
+          <Table.CellHeader>IEP description</Table.CellHeader>
           <Table.CellHeader>Establishment</Table.CellHeader>
         </Table.Row>
         {results.map(row => (

--- a/src/IepHistory/IepHistoryContainer.js
+++ b/src/IepHistory/IepHistoryContainer.js
@@ -74,7 +74,7 @@ class IepHistoryContainer extends Component {
     const { offenderNo, handleError, setLoadedDispatch } = this.props
     return (
       <OffenderPage
-        title={({ firstName, lastName }) => `IEP history for ${firstName} ${lastName}`}
+        title={({ firstName, lastName }) => `IEP details for ${firstName} ${lastName}`}
         handleError={handleError}
         offenderNumber={offenderNo}
         setLoaded={setLoadedDispatch}

--- a/src/IepHistory/IepHistoryForm.js
+++ b/src/IepHistory/IepHistoryForm.js
@@ -72,9 +72,7 @@ export const FormFields = ({ now, errors, establishments, levels, submitting, va
               id="establishment-select"
               value={values.iepEstablishment}
             >
-              <option value="" disabled hidden>
-                All
-              </option>
+              <option value="">All</option>
               {establishments.map(estb => (
                 <option key={estb.agencyId} value={estb.agencyId}>
                   {estb.description}
@@ -91,9 +89,7 @@ export const FormFields = ({ now, errors, establishments, levels, submitting, va
               id="iep-level-select"
               value={values.iepLevel}
             >
-              <option value="" disabled hidden>
-                All
-              </option>
+              <option value="">All</option>
               {levels.map(level => (
                 <option key={level} value={level}>
                   {level}

--- a/src/IepHistory/__snapshots__/IepHistory.test.js.snap
+++ b/src/IepHistory/__snapshots__/IepHistory.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`IEP history should render the current IEP level correctly 1`] = `
 <div
-  className="current-iep sc-iwsKbI jnBmwk"
+  className="current-iep sc-gZMcBi bZTBmE"
 >
   <div
-    className="sc-htoDjs bAoqyZ"
+    className="sc-dnqmqq fhodxA"
   >
     <div
-      className="sc-dnqmqq kSWurI"
+      className="sc-iwsKbI kueFGx"
     >
       <strong
         className="label"
@@ -20,7 +20,7 @@ exports[`IEP history should render the current IEP level correctly 1`] = `
       </p>
     </div>
     <div
-      className="sc-dnqmqq kSWurI"
+      className="sc-iwsKbI kueFGx"
     >
       <strong
         className="label"
@@ -32,7 +32,7 @@ exports[`IEP history should render the current IEP level correctly 1`] = `
       </p>
     </div>
     <div
-      className="sc-dnqmqq kSWurI"
+      className="sc-iwsKbI kueFGx"
     >
       <strong
         className="label"
@@ -49,17 +49,17 @@ exports[`IEP history should render the current IEP level correctly 1`] = `
 
 exports[`IEP history should render the iep history table correctly 1`] = `
 Array [
+  <h2
+    className="sc-bZQynM ifeWwe"
+  >
+    IEP history
+  </h2>,
   <div
-    className="sc-gzVnrw gIvEvv"
+    className="sc-htoDjs xQRkw"
   >
     <table
       className="results sc-EHOje kCMYgv"
     >
-      <caption
-        className="sc-htpNat iqxUVN"
-      >
-        IEP history
-      </caption>
       <tbody
         className="sc-bwzfXH uTxCW"
       >
@@ -125,16 +125,11 @@ Array [
     </table>
   </div>,
   <div
-    className="sc-bZQynM iVQEAa"
+    className="sc-gzVnrw VtCIX"
   >
     <table
       className="sc-EHOje kCMYgv"
     >
-      <caption
-        className="sc-htpNat iqxUVN"
-      >
-        IEP history
-      </caption>
       <tbody
         className="sc-bwzfXH uTxCW"
       >

--- a/src/IepHistory/__snapshots__/IepHistory.test.js.snap
+++ b/src/IepHistory/__snapshots__/IepHistory.test.js.snap
@@ -69,12 +69,12 @@ Array [
           <th
             className="sc-bxivhb kZbmwT"
           >
-            Date and Time
+            Date and time
           </th>
           <th
             className="sc-bxivhb kZbmwT"
           >
-            IEP Description
+            IEP description
           </th>
           <th
             className="sc-bxivhb kZbmwT"
@@ -139,12 +139,12 @@ Array [
           <th
             className="sc-bxivhb kZbmwT"
           >
-            Date and Time
+            Date and time
           </th>
           <th
             className="sc-bxivhb kZbmwT"
           >
-            IEP Description
+            IEP description
           </th>
           <th
             className="sc-bxivhb kZbmwT"

--- a/src/IepHistory/__snapshots__/IepHistoryForm.test.js.snap
+++ b/src/IepHistory/__snapshots__/IepHistoryForm.test.js.snap
@@ -5,7 +5,7 @@ exports[`IEP history Form should render the iep history table correctly 1`] = `
   onSubmit={[Function]}
 >
   <div
-    className="sc-chPdSV bcSAZc"
+    className="sc-chPdSV ddsHXB"
   >
     <div
       className="sc-bdVaJa gkOpjT"
@@ -17,7 +17,7 @@ exports[`IEP history Form should render the iep history table correctly 1`] = `
           className="sc-bdVaJa gkOpjT"
         >
           <h3
-            className="sc-kGXeez lkXioC sc-fjdhpX TnkYd"
+            className="sc-kGXeez iHgsBB sc-fjdhpX TnkYd"
           >
             Filters
           </h3>
@@ -46,8 +46,6 @@ exports[`IEP history Form should render the iep history table correctly 1`] = `
                 value=""
               >
                 <option
-                  disabled={true}
-                  hidden={true}
                   value=""
                 >
                   All
@@ -81,8 +79,6 @@ exports[`IEP history Form should render the iep history table correctly 1`] = `
                 value=""
               >
                 <option
-                  disabled={true}
-                  hidden={true}
                   value=""
                 >
                   All
@@ -104,7 +100,7 @@ exports[`IEP history Form should render the iep history table correctly 1`] = `
           className="sc-bdVaJa gkOpjT"
         >
           <span
-            className="sc-kpOJdX uKFLa"
+            className="sc-kpOJdX irqhhZ"
           >
             Date Range
           </span>

--- a/src/routePaths.js
+++ b/src/routePaths.js
@@ -1,7 +1,7 @@
 export default {
   establishmentRoll: '/establishment-roll',
   inToday: '/establishment-roll/in-today',
-  iepHistory: '/offenders/:offenderNo/iep-level',
+  iepHistory: '/offenders/:offenderNo/iep-details',
   outToday: '/establishment-roll/out-today',
   inReception: '/establishment-roll/in-reception',
   currentlyOut: '/establishment-roll/:livingUnitId/currently-out',

--- a/src/routes.js
+++ b/src/routes.js
@@ -13,7 +13,7 @@ export default [
 
   { path: '/offenders', breadcrumb: null },
   { path: '/offenders/:offenderNo', breadcrumb: OffenderBreadcrumb, renderDirectly: true },
-  { path: '/offenders/:offenderNo/iep-level', breadcrumb: 'IEP level' },
+  { path: '/offenders/:offenderNo/iep-details', breadcrumb: 'IEP details' },
   // Below are temporary as latest version of react-router-breadcrumbs-hoc leaves hyphens in the breadcrumb text
   { path: '/establishment-roll', breadcrumb: 'Establishment roll' },
   { path: '/search-prisoner-whereabouts', breadcrumb: 'Search prisoner whereabouts' },


### PR DESCRIPTION
Minor interface tweaks to IEP details page:

1. Change `IEP history/level` to `IEP details` in page heading, breadcrumbs and urls.
2. Fiddle with padding on form to reduce empty grey space.
3. User lighter grey colour for form background to match other filter forms on Quick Look such as Case Notes.
4. Increase size of `IEP history` heading
5. Enable `All` option in filters

![screenshot-localhost-3002-2019 05 16-15-03-29](https://user-images.githubusercontent.com/4950775/57912556-8725e500-7882-11e9-8477-bf7ce0affb94.png)
 