### PR TITLE
NN-1927: Update case switching for IEP details and Adjudications

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -189,9 +189,11 @@ class App extends React.Component {
 
   switchCaseLoad = async (newCaseload, location) => {
     const { switchAgencyDispatch, config } = this.props
+    const redirectToNotm =
+      location.pathname.includes('global-search-results') || location.pathname.includes('offenders')
 
     try {
-      if (location.pathname.includes('global-search-results')) {
+      if (redirectToNotm) {
         await axios.put('/api/setactivecaseload', { caseLoadId: newCaseload })
         window.location.assign(config.notmEndpointUrl)
       } else {


### PR DESCRIPTION
Currently both of the above pages redirect to wherearebouts home,
which is not the where the user got to them. This updates the switchCaseload
logic to detect pages under the 'offenders' path and to redirect those
to the notm interface instead.