### PR TITLE
NN-1677 Adding garbles/flag to add support for adding feature flags

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -9,6 +9,7 @@ module.exports = {
     url: process.env.PRISON_STAFF_HUB_UI_URL || `http://localhost:${process.env.PORT || 3002}/`,
     maximumFileUploadSizeInMb: process.env.MAXIMUM_FILE_UPLOAD_SIZE_IN_MB || 200,
     updateAttendanceEnabled: process.env.UPDATE_ATTENDANCE_ENABLED === 'true',
+    featureFlags: { adjudicationDetailsLinkEnabled: process.env.ATTENDANCE_DETAIL_LINK_ENABLED === 'true' },
   },
   analytics: {
     googleAnalyticsId: process.env.GOOGLE_ANALYTICS_ID,

--- a/backend/controllers/getConfig.js
+++ b/backend/controllers/getConfig.js
@@ -8,6 +8,7 @@ const getConfiguration = asyncMiddleware(async (req, res) =>
     googleAnalyticsId: config.analytics.googleAnalyticsId,
     licencesUrl: config.app.licencesUrl,
     updateAttendanceEnabled: config.app.updateAttendanceEnabled,
+    flags: config.app.featureFlags,
   })
 )
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "express-form-data": "^2.0.7",
     "final-form": "^4.11.0",
     "final-form-calculate": "^1.3.1",
+    "flag": "^4.1.0",
     "govuk-colours": "^1.0.3",
     "govuk-elements-sass": "^3.1.2",
     "govuk_frontend_toolkit": "^7.5.0",

--- a/src/App.js
+++ b/src/App.js
@@ -44,12 +44,13 @@ import AdjudicationDetailContainer from './Adjudications/AdjudicationDetail/Adju
 import routePaths from './routePaths'
 import Content from './Components/Content'
 import AddPrisonerContainer from './BulkAppointments/AddPrisoners/AddPrisonersContainer'
+import { setFlagsAction } from './flags'
 
 const axios = require('axios')
 
 class App extends React.Component {
   async componentWillMount() {
-    const { configDispatch, setErrorDispatch } = this.props
+    const { configDispatch, setErrorDispatch, setFlagsDispatch } = this.props
 
     axios.interceptors.response.use(
       config => {
@@ -74,6 +75,7 @@ class App extends React.Component {
       }
 
       configDispatch(config.data)
+      setFlagsDispatch(config.data.flags)
     } catch (error) {
       setErrorDispatch(error.message)
     }
@@ -574,6 +576,7 @@ const mapDispatchToProps = dispatch => ({
   setTermsVisibilityDispatch: shouldShowTerms => dispatch(setTermsVisibility(shouldShowTerms)),
   switchAgencyDispatch: agencyId => dispatch(switchAgency(agencyId)),
   userDetailsDispatch: user => dispatch(setUserDetails(user)),
+  setFlagsDispatch: flags => dispatch(setFlagsAction(flags)),
 })
 
 const AppContainer = connect(

--- a/src/flags.js
+++ b/src/flags.js
@@ -1,0 +1,8 @@
+import createFlags from 'flag'
+import { createReduxBindings } from 'flag/redux'
+
+const { FlagsProvider, Flag } = createFlags()
+
+const { setFlagsAction, createFlagsReducer, ConnectedFlagsProvider } = createReduxBindings(FlagsProvider)
+
+export { Flag, setFlagsAction, createFlagsReducer, ConnectedFlagsProvider }

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,13 @@
 import '@babel/polyfill'
 import React from 'react'
 import ReactDOM from 'react-dom'
+
 import './index.scss'
 import { Provider } from 'react-redux'
 import { createStore, applyMiddleware, compose } from 'redux'
 import thunkMiddleware from 'redux-thunk'
 import logger from 'redux-logger'
+import { ConnectedFlagsProvider } from './flags'
 import allocationApp from './redux/reducers'
 
 // Logger with default options
@@ -16,7 +18,9 @@ const store = createStore(allocationApp, composeEnhancers(applyMiddleware(thunkM
 
 ReactDOM.render(
   <Provider store={store}>
-    <AppContainer />
+    <ConnectedFlagsProvider store={store}>
+      <AppContainer />
+    </ConnectedFlagsProvider>
   </Provider>,
   document.getElementById('root')
 )

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -7,6 +7,7 @@ import adjudicationHistory from './adjudications'
 
 import offenderDetails from './offenderDetails'
 import iepHistory from './iepHistory'
+import { createFlagsReducer } from '../../flags'
 
 export function defaultPeriod(time) {
   const midnight = moment('12:00a', 'HH:mm a')
@@ -301,6 +302,7 @@ const prisonStaffHubApp = combineReducers({
   adjudicationHistory,
   offenderDetails,
   iepHistory,
+  flags: createFlagsReducer({}),
 })
 
 export default prisonStaffHubApp

--- a/yarn.lock
+++ b/yarn.lock
@@ -700,6 +700,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.4.3":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.1.0", "@babel/template@^7.1.2", "@babel/template@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
@@ -1352,6 +1359,14 @@
     "@types/express-serve-static-core" "*"
     "@types/serve-static" "*"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/mime@*":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
@@ -1360,6 +1375,11 @@
   version "10.12.11"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.11.tgz#715c476c99a5f6898a1ae61caf9825e43c03912e"
 
+"@types/prop-types@*":
+  version "15.7.1"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.1.tgz#f1a11e7babb0c3cad68100be381d1e064c68f1f6"
+  integrity sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg==
+
 "@types/prop-types@^15.5.3":
   version "15.5.6"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.5.6.tgz#9c03d3fed70a8d517c191b7734da2879b50ca26c"
@@ -1367,6 +1387,38 @@
 "@types/range-parser@*":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.2.tgz#fa8e1ad1d474688a757140c91de6dace6f4abc8d"
+
+"@types/react-dom@^16.8.3":
+  version "16.8.4"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.8.4.tgz#7fb7ba368857c7aa0f4e4511c4710ca2c5a12a88"
+  integrity sha512-eIRpEW73DCzPIMaNBDP5pPIpK1KXyZwNgfxiVagb5iGiz6da+9A5hslSX6GAQKdO7SayVCS/Fr2kjqprgAvkfA==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-redux@^7.0.7":
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.0.9.tgz#4825ee2872c44768916304b6bb8df5b46d443b88"
+  integrity sha512-fMVX9SneWWw68d/JoeNUh6hj42kx2G30YhPdCYJTOv3xqbJ1xzIz6tEM/xzi7nBvpNbwZkSa9TMsV06kWOFIIg==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
+
+"@types/react@*", "@types/react@^16.8.12":
+  version "16.8.19"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.19.tgz#629154ef05e2e1985cdde94477deefd823ad9be3"
+  integrity sha512-QzEzjrd1zFzY9cDlbIiFvdr+YUmefuuRYrPxmkwG0UQv5XF35gFIi7a95m1bNVcFU0VimxSZ5QVGSiBmlggQXQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
+"@types/redux@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@types/redux/-/redux-3.6.0.tgz#f1ebe1e5411518072e4fdfca5c76e16e74c1399a"
+  integrity sha1-8evh5UEVGAcuT9/KXHbhbnTBOZo=
+  dependencies:
+    redux "*"
 
 "@types/serve-static@*":
   version "1.13.2"
@@ -3814,6 +3866,11 @@ cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
+csstype@^2.2.0:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.5.tgz#1cd1dff742ebf4d7c991470ae71e12bb6751e034"
+  integrity sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==
+
 csv-parse@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.3.1.tgz#b2b92a4068106d6713952050593b2be06ec1a577"
@@ -3917,6 +3974,11 @@ decompress-response@^3.2.0, decompress-response@^3.3.0:
 dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+
+deep-computed@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/deep-computed/-/deep-computed-0.2.0.tgz#493170520e96fc7a971b36289744d3646c00d573"
+  integrity sha512-KLnX3qEoMZP+McYQSEfvLyHCkzuISoDG6zznkJcwVqLqTG3u0K3hJnfqp9WYSRYJxDEx3gs47XJVwDu8QwjGRQ==
 
 deep-diff@^0.3.5:
   version "0.3.8"
@@ -5050,6 +5112,22 @@ first-chunk-stream@^2.0.0:
   dependencies:
     readable-stream "^2.0.2"
 
+flag@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/flag/-/flag-4.1.0.tgz#b65e01b685737b2463219559234c833fd091fccc"
+  integrity sha512-jRTqvaq2c6Kuzt/sOAK5iWdn/h4Okv9MPhiO7756/z+7Y8cxrVpapRdY0PFzvEYI6lH58Kh1zOjRsQ1fzc07wg==
+  dependencies:
+    deep-computed "^0.2.0"
+    lodash "^4.17.11"
+    useful-types "^0.2.1"
+  optionalDependencies:
+    "@types/react" "^16.8.12"
+    "@types/react-dom" "^16.8.3"
+    "@types/react-redux" "^7.0.7"
+    "@types/redux" "^3.6.0"
+    react-redux "^7.0.2"
+    redux "^4.0.1"
+
 flat-cache@^1.2.1:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.4.tgz#2c2ef77525cc2929007dfffa1dd314aa9c9dee6f"
@@ -5687,6 +5765,13 @@ hoist-non-react-statics@^3.1.0:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.0.tgz#d21b9fc72b50fdc38c5d88f6e2c52f2c2dbe5ee2"
   dependencies:
     react-is "^16.3.2"
+
+hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -9339,15 +9424,15 @@ react-is@^16.3.2, react-is@^16.6.0, react-is@^16.6.3:
   version "16.6.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
 
+react-is@^16.7.0, react-is@^16.8.6:
+  version "16.8.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
+
 react-is@^16.8.1:
   version "16.8.4"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.4.tgz#90f336a68c3a29a096a3d648ab80e87ec61482a2"
   integrity sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==
-
-react-is@^16.8.6:
-  version "16.8.6"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
-  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -9392,6 +9477,18 @@ react-redux@5.1.1:
     prop-types "^15.6.1"
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
+
+react-redux@^7.0.2:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.0.3.tgz#983c5a6de81cb1e696bd1c090ba826545f9170f1"
+  integrity sha512-vYZA7ftOYlDk3NetitsI7fLjryt/widNl1SLXYvFenIpm7vjb4ryK0EeFrgn62usg5fYkyIAWNUPKnwWPevKLg==
+  dependencies:
+    "@babel/runtime" "^7.4.3"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
 
 react-router-breadcrumbs-hoc@^3.2.0:
   version "3.2.0"
@@ -9652,7 +9749,7 @@ redux-thunk@^2.3.0:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
-redux@^4.0.0:
+redux@*, redux@^4.0.0, redux@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
   dependencies:
@@ -9688,6 +9785,11 @@ regenerator-runtime@^0.11.0:
 regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"
@@ -11260,6 +11362,11 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+useful-types@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/useful-types/-/useful-types-0.2.1.tgz#3e2c5dc975f55aca97e0b99e12b8546af1da82bc"
+  integrity sha512-mgRauWJvmQuRs6lLjkTCrGw5lLt5rVMsFQgEehREkKkR+f+yag3CEhG0mPvc+PenfhrjYz8t9ng789/mdTh1Rw==
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Adding [garbles/flag](https://github.com/garbles/flag) to allow managing and implementing feature flags.

Flags registered in `backend/config.js` like: 
```js
app: {
  featureFlags: { 
    myFlagName: process.env.MY_FLAG_NAME === 'true' 
  }
}
```

Will then be available to `Flag`s in react components:
```js
  <Flag
    name={['myFlagName']}
    render={() => (
      <span>Feature Enabled</span>
    )}
    fallbackRender={() => (
      <span>Feature Disabled</span>
    )}
  />
```