### PR TITLE
Nn 2012 use locked property for radio button logic

### DIFF
--- a/backend/controllers/activityList.js
+++ b/backend/controllers/activityList.js
@@ -20,8 +20,8 @@ const sortActivitiesByEventThenByLastName = data => {
 const extractAttendanceInfo = (attendanceInformation, event) => {
   if (attendanceInformation && attendanceInformation.length > 0) {
     const offenderAttendanceInfo = attendanceInformation.find(attendance => attendance.bookingId === event.bookingId)
-    const { id, absentReason, attended, paid, comments } = offenderAttendanceInfo || {}
-    const attendanceInfo = { id, absentReason, comments, paid }
+    const { id, absentReason, attended, paid, comments, locked } = offenderAttendanceInfo || {}
+    const attendanceInfo = { id, absentReason, comments, paid, locked }
 
     if (offenderAttendanceInfo && absentReason) attendanceInfo.other = true
 

--- a/backend/tests/activityList.test.js
+++ b/backend/tests/activityList.test.js
@@ -476,6 +476,7 @@ describe('Activity list controller', async () => {
     it('should load attendance details', async () => {
       whereaboutsApi.getAttendance.mockReturnValue([
         {
+          id: 1,
           absentReason: 'Acceptable absence',
           attended: false,
           paid: true,
@@ -486,8 +487,10 @@ describe('Activity list controller', async () => {
           period: 'AM',
           prisonId: 'LEI',
           comments: 'Some comments or case note text.',
+          locked: true,
         },
         {
+          id: 2,
           absentReason: 'Refused',
           attended: true,
           paid: false,
@@ -497,8 +500,10 @@ describe('Activity list controller', async () => {
           eventLocationId: 1,
           period: 'AM',
           prisonId: 'LEI',
+          locked: false,
         },
         {
+          id: 3,
           attended: true,
           paid: true,
           bookingId: 3,
@@ -507,6 +512,7 @@ describe('Activity list controller', async () => {
           eventLocationId: 1,
           period: 'AM',
           prisonId: 'LEI',
+          locked: true,
         },
       ])
 
@@ -542,6 +548,8 @@ describe('Activity list controller', async () => {
             comments: 'Some comments or case note text.',
             other: true,
             paid: true,
+            locked: true,
+            id: 1,
           },
         },
         {
@@ -560,6 +568,8 @@ describe('Activity list controller', async () => {
             comments: undefined,
             other: true,
             paid: false,
+            locked: false,
+            id: 2,
           },
         },
         {
@@ -578,6 +588,8 @@ describe('Activity list controller', async () => {
             comments: undefined,
             pay: true,
             paid: true,
+            locked: true,
+            id: 3,
           },
         },
       ])

--- a/src/ResultsActivity/ResultsActivity.js
+++ b/src/ResultsActivity/ResultsActivity.js
@@ -72,7 +72,6 @@ class ResultsActivity extends Component {
       sortOrder,
       orderField,
       setColumnSort,
-      payable,
       agencyId,
       handleError,
       setOffenderAttendanceData,
@@ -161,18 +160,16 @@ class ResultsActivity extends Component {
             <span>Received</span>
           </div>
         </th>
-        {payable && (
-          <Flag
-            name={['updateAttendanceEnabled']}
-            render={() => (
-              <React.Fragment>
-                <th className="straight width5 no-print">Pay</th>
-                <th className="straight width5 no-print">Other</th>
-              </React.Fragment>
-            )}
-            fallbackRender={() => <></>}
-          />
-        )}
+        <Flag
+          name={['updateAttendanceEnabled']}
+          render={() => (
+            <React.Fragment>
+              <th className="straight width5 no-print">Pay</th>
+              <th className="straight width5 no-print">Other</th>
+            </React.Fragment>
+          )}
+          fallbackRender={() => <></>}
+        />
       </tr>
     )
 
@@ -272,21 +269,19 @@ class ResultsActivity extends Component {
                 <input id={`col1_${index}`} type="checkbox" name="ch1" disabled />
               </div>
             </td>
-            {payable && (
-              <Flag
-                name={['updateAttendanceEnabled']}
-                render={() => (
-                  <PayOptions
-                    offenderDetails={offenderDetails}
-                    updateOffenderAttendance={updateOffenderAttendance}
-                    openModal={this.openModal}
-                    closeModal={this.closeModal}
-                    date={date}
-                  />
-                )}
-                fallbackRender={() => <></>}
-              />
-            )}
+            <Flag
+              name={['updateAttendanceEnabled']}
+              render={() => (
+                <PayOptions
+                  offenderDetails={offenderDetails}
+                  updateOffenderAttendance={updateOffenderAttendance}
+                  openModal={this.openModal}
+                  closeModal={this.closeModal}
+                  date={date}
+                />
+              )}
+              fallbackRender={() => <></>}
+            />
           </tr>
         )
       })
@@ -370,7 +365,6 @@ ResultsActivity.propTypes = {
   setColumnSort: PropTypes.func.isRequired,
   orderField: PropTypes.string.isRequired,
   sortOrder: PropTypes.string.isRequired,
-  payable: PropTypes.bool.isRequired,
   handleError: PropTypes.func.isRequired,
   setOffenderAttendanceData: PropTypes.func.isRequired,
   resetErrorDispatch: PropTypes.func.isRequired,

--- a/src/ResultsActivity/ResultsActivityContainer.js
+++ b/src/ResultsActivity/ResultsActivityContainer.js
@@ -26,9 +26,6 @@ class ResultsActivityContainer extends Component {
     this.handlePrint = this.handlePrint.bind(this)
     this.setColumnSort = this.setColumnSort.bind(this)
     this.getActivityList = this.getActivityList.bind(this)
-    this.state = {
-      payable: true,
-    }
   }
 
   async componentDidMount() {
@@ -101,7 +98,6 @@ class ResultsActivityContainer extends Component {
     } catch (error) {
       handleError(error)
     }
-    this.setState({ payable: this.isPayableDate() })
     setLoadedDispatch(true)
   }
 
@@ -113,19 +109,6 @@ class ResultsActivityContainer extends Component {
         .map(a => a.userDescription)
         .find(a => !!a) || null
     )
-  }
-
-  isPayableDate = () => {
-    const { date } = this.props
-
-    const selectedDate = moment(date, 'DD-MM-YYYY')
-    const historicRange = moment()
-      .subtract(6, 'd')
-      .startOf('day')
-
-    if (selectedDate.isBefore(historicRange)) return false
-
-    return true
   }
 
   handlePrint() {
@@ -140,7 +123,6 @@ class ResultsActivityContainer extends Component {
 
   render() {
     const { resetErrorDispatch, setOffenderPaymentDataDispatch } = this.props
-    const { payable } = this.state
     const activityName = this.getActivityName()
 
     return (
@@ -150,7 +132,6 @@ class ResultsActivityContainer extends Component {
           getActivityList={this.getActivityList}
           resetErrorDispatch={resetErrorDispatch}
           setColumnSort={this.setColumnSort}
-          payable={payable}
           handleError={this.handleError}
           setOffenderAttendanceData={setOffenderPaymentDataDispatch}
           {...this.props}

--- a/src/ResultsActivity/elements/PayOptions/PayOptions.js
+++ b/src/ResultsActivity/elements/PayOptions/PayOptions.js
@@ -14,7 +14,7 @@ function PayOptions({ offenderDetails, updateOffenderAttendance, date, openModal
   const [selectedOption, setSelectedOption] = useState()
   const [isPaying, setIsPaying] = useState()
   const { offenderNo, bookingId, eventId, eventLocationId, offenderIndex, attendanceInfo } = offenderDetails
-  const { id, pay, other } = attendanceInfo || {}
+  const { id, pay, other, locked } = attendanceInfo || {}
 
   const payOffender = async () => {
     const attendanceDetails = {
@@ -55,6 +55,7 @@ function PayOptions({ offenderDetails, updateOffenderAttendance, date, openModal
     <Fragment>
       <Option data-qa="pay-option">
         {!isPaying &&
+          !locked &&
           offenderNo &&
           eventId && (
             <Radio onChange={payOffender} name={offenderNo} value="pay" checked={selectedOption === 'pay'}>
@@ -65,7 +66,8 @@ function PayOptions({ offenderDetails, updateOffenderAttendance, date, openModal
       </Option>
 
       <Option data-qa="other-option">
-        {offenderNo &&
+        {!locked &&
+          offenderNo &&
           eventId && (
             <>
               <Radio name={offenderNo} onChange={renderForm} value="other" checked={selectedOption === 'other'}>

--- a/src/ResultsActivity/elements/PayOptions/PayOptions.test.js
+++ b/src/ResultsActivity/elements/PayOptions/PayOptions.test.js
@@ -93,4 +93,13 @@ describe('<PayOptions />', () => {
     const detailsLink = testInstance.findAllByType(UpdateLink)
     expect(detailsLink.length).toBe(0)
   })
+
+  it('should not display radio buttons when attendance is locked', () => {
+    props.offenderDetails.attendanceInfo.locked = true
+    act(() => testRenderer.update(<PayOptions {...props} />))
+    const payOption = testInstance.findByProps({ 'data-qa': 'pay-option' }).findAllByType(Radio)
+    const otherOption = testInstance.findByProps({ 'data-qa': 'other-option' }).findAllByType(Radio)
+    expect(payOption.length).toBe(0)
+    expect(otherOption.length).toBe(0)
+  })
 })


### PR DESCRIPTION
Replace the current logic for hiding Pay/Other with a check for whether the attendance is locked. Display the Pay/Other column headings regardless as different rows could have different displays (some attendances become locked before others). Hide radio buttons if the attendance is locked.