### PR TITLE
NN-1961: Update GA events

### DIFF
--- a/src/IepDetails/IepChangeContainer.js
+++ b/src/IepDetails/IepChangeContainer.js
@@ -54,7 +54,15 @@ class IepChangeContainer extends Component {
   }
 
   changeIepLevel = async values => {
-    const { offenderNo, handleError, levels, history, raiseAnalyticsEvent } = this.props
+    const {
+      offenderNo,
+      handleError,
+      levels,
+      history,
+      raiseAnalyticsEvent,
+      currentIepLevel,
+      activeCaseLoadId,
+    } = this.props
     const level = levels.find(l => l.value === values.level)
 
     try {
@@ -62,7 +70,7 @@ class IepChangeContainer extends Component {
         iepLevel: values.level,
         comment: values.reason,
       })
-      raiseAnalyticsEvent(LevelSelected(level.title, values.reason))
+      raiseAnalyticsEvent(LevelSelected(level.title, currentIepLevel, activeCaseLoadId))
       history.goBack()
       notify.show(`IEP Level successfully changed to ${level.title}`, 'success')
     } catch (error) {

--- a/src/IepDetails/IepChangeGaEvents.js
+++ b/src/IepDetails/IepChangeGaEvents.js
@@ -3,9 +3,9 @@ export const iepChangeGaEvent = {
   label: 'IEP change',
 }
 
-export const LevelSelected = (level, reason) => ({
+export const LevelSelected = (toLevel, fromLevel, agencyId) => ({
   ...iepChangeGaEvent,
-  action: `level changed to ${level} with reason: ${reason}`,
+  action: `level changed from ${fromLevel} to ${toLevel} at ${agencyId}`,
 })
 
 export const ChangeAbandonment = () => ({

--- a/src/IepDetails/IepChangeGaEvents.test.js
+++ b/src/IepDetails/IepChangeGaEvents.test.js
@@ -2,12 +2,13 @@ import { iepChangeGaEvent, LevelSelected, ChangeAbandonment } from './IepChangeG
 
 describe('Bulk IEP level change ga events', () => {
   it('should create an ga event of type of level changed', () => {
-    const level = 'Basic'
-    const reason = 'Some reason'
+    const toLevel = 'Basic'
+    const fromLevel = 'Enhanced'
+    const agencyId = 'LEI'
 
-    expect(LevelSelected(level, reason)).toEqual({
+    expect(LevelSelected(toLevel, fromLevel, agencyId)).toEqual({
       ...iepChangeGaEvent,
-      action: `level changed to ${level} with reason: ${reason}`,
+      action: `level changed from ${fromLevel} to ${toLevel} at ${agencyId}`,
     })
   })
 


### PR DESCRIPTION
Previously the GA events included the new IEP level and the reason
for the change. We determined the reason was not necessary and should be
replaced by the offender's previous level and the agency where
the change was made.