### PR TITLE
NN-2074 add client side validation on comments

### DIFF
--- a/src/ResultsActivity/elements/PayOtherForm/PayOtherForm.js
+++ b/src/ResultsActivity/elements/PayOtherForm/PayOtherForm.js
@@ -46,6 +46,10 @@ export function PayOtherForm({
       formErrors.push({ targetName: 'comments', text: `Enter ${commentOrCaseNote(values.absentReason)}` })
     }
 
+    if (values.comments && values.comments.length > 240) {
+      formErrors.push({ targetName: 'comments', text: 'Maximum length should not exceed 240 characters' })
+    }
+
     if (formErrors.length > 0) return { [FORM_ERROR]: formErrors }
 
     const attendanceUpdated = await submitHandler(values)

--- a/src/ResultsActivity/elements/PayOtherForm/PayOtherForm.test.js
+++ b/src/ResultsActivity/elements/PayOtherForm/PayOtherForm.test.js
@@ -133,7 +133,7 @@ describe('<PayOtherForm />', () => {
         expect(errors.at(0).text()).toEqual('Enter case note')
       })
 
-      it('should show correct maximum length validation message for the event out come text', async () => {
+      it('should show correct maximum length validation message for the comments text', async () => {
         yesRadio.instance().checked = true
         yesRadio.simulate('change', noRadio)
         reasonSelector.instance().value = 'AcceptableAbsence'

--- a/src/ResultsActivity/elements/PayOtherForm/PayOtherForm.test.js
+++ b/src/ResultsActivity/elements/PayOtherForm/PayOtherForm.test.js
@@ -3,6 +3,11 @@ import { mount } from 'enzyme'
 import { PayOtherForm } from './PayOtherForm'
 import IEPCreated from '../../../IEPCreated'
 
+const buildLargeText = length =>
+  Array.from([...Array(length).keys()])
+    .map(_ => 'A')
+    .join('')
+
 describe('<PayOtherForm />', () => {
   const submitForm = async formWrapper => {
     await formWrapper.find('form').simulate('submit')
@@ -126,6 +131,23 @@ describe('<PayOtherForm />', () => {
 
         const errors = wrapper.find('ErrorSummary').find('li')
         expect(errors.at(0).text()).toEqual('Enter case note')
+      })
+
+      it('should show correct maximum length validation message for the event out come text', async () => {
+        yesRadio.instance().checked = true
+        yesRadio.simulate('change', noRadio)
+        reasonSelector.instance().value = 'AcceptableAbsence'
+        reasonSelector.simulate('change', reasonSelector)
+
+        commentInput.instance().value = buildLargeText(241)
+
+        commentInput.simulate('change', commentInput)
+        wrapper.update()
+
+        await submitForm(wrapper)
+
+        const errors = wrapper.find('ErrorSummary').find('li')
+        expect(errors.at(0).text()).toEqual('Maximum length should not exceed 240 characters')
       })
     })
 

--- a/src/ResultsActivity/elements/PayOtherForm/PayOtherForm.test.js
+++ b/src/ResultsActivity/elements/PayOtherForm/PayOtherForm.test.js
@@ -3,11 +3,6 @@ import { mount } from 'enzyme'
 import { PayOtherForm } from './PayOtherForm'
 import IEPCreated from '../../../IEPCreated'
 
-const buildLargeText = length =>
-  Array.from([...Array(length).keys()])
-    .map(_ => 'A')
-    .join('')
-
 describe('<PayOtherForm />', () => {
   const submitForm = async formWrapper => {
     await formWrapper.find('form').simulate('submit')
@@ -139,7 +134,7 @@ describe('<PayOtherForm />', () => {
         reasonSelector.instance().value = 'AcceptableAbsence'
         reasonSelector.simulate('change', reasonSelector)
 
-        commentInput.instance().value = buildLargeText(241)
+        commentInput.instance().value = 'A'.repeat(241)
 
         commentInput.simulate('change', commentInput)
         wrapper.update()


### PR DESCRIPTION
The limit of 240 applies to both event outcomes and IEP warnings.