### PR TITLE
Nn 2059 houseblock list attendance values

### DIFF
--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/specs/HouseblockSpecification.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/specs/HouseblockSpecification.groovy
@@ -144,6 +144,7 @@ class HouseblockSpecification extends BrowserReportingSpec {
         def texts = tableRows*.text()
         texts[1].contains("Anderson, Arthur A-1-1 A1234AA")
         texts[2].contains("Balog, Eugene A-1-2 A1234AB")
+        texts[3].contains("Not Recorded")
 
         when: "I go to the search page afresh"
         browser.to SearchPage
@@ -327,12 +328,7 @@ class HouseblockSpecification extends BrowserReportingSpec {
         at HouseblockPage
 
         tableRows[1].find('td')[attendanceColumn].text() == 'Received'
-        tableRows[3].find('td')[attendanceColumn].find('[data-qa="other-message"]').click()
-
-        def payRadios = $(name: "pay").module(RadioButtons)
-        payRadios.checked == 'no'
-        absentReasonForm.form.absentReason == 'UnacceptableAbsence'
-        absentReasonForm.form.comments == 'Never turned up.'
+        tableRows[3].find('td')[attendanceColumn].text() == 'Unacceptable - IEP'
     }
 
     def "should mark an offender as not attended with absent reason"() {

--- a/src/ResultsActivity/elements/PayOptions/PayOptions.js
+++ b/src/ResultsActivity/elements/PayOptions/PayOptions.js
@@ -49,12 +49,13 @@ function PayOptions({ offenderDetails, updateOffenderAttendance, date, noPay, sh
     )
 
   const allowUpdate = selectedOption === 'other' && absentReason
+  const notRecorded = !paid && !other && !isWithinLastWeek(date)
   const showRadioButton = !locked && offenderNo && eventId && isWithinLastWeek(date)
 
   const payMessage = () => {
     if (paid && locked) return 'Paid'
     if (!paid && locked) return 'Not paid'
-    if (!paid && !other && !isWithinLastWeek(date)) return 'Not Recorded'
+    if (notRecorded) return 'Not Recorded'
     return null
   }
 
@@ -87,10 +88,16 @@ function PayOptions({ offenderDetails, updateOffenderAttendance, date, noPay, sh
             </Radio>
           )}
         {allowUpdate && (
-          <UpdateLink role="link" onClick={renderForm}>
-            <OtherMessage data-qa="other-message">{absentReason.name}</OtherMessage>
-          </UpdateLink>
+          <Fragment>
+            {noPay && <OtherMessage data-qa="other-message">{absentReason.name}</OtherMessage>}
+            {!noPay && (
+              <UpdateLink role="link" onClick={renderForm}>
+                <OtherMessage data-qa="other-message">{absentReason.name}</OtherMessage>
+              </UpdateLink>
+            )}
+          </Fragment>
         )}
+        {!allowUpdate && notRecorded && noPay && <OtherMessage data-qa="other-message">Not Recorded</OtherMessage>}
       </Option>
     </Fragment>
   )


### PR DESCRIPTION
For https://dsdmoj.atlassian.net/browse/NN-2059

This adds a bit more complexity in what we show on the houseblock lists. Unlike the activity lists, the absence reason here is not a link so is not editable. Also, if we have no attendance data for a locked record, we should 'Not Recorded'.