### PR TITLE
NN-2103: Remove Entry from possible options for Change IEP

### DIFF
--- a/backend/controllers/iepDetails.js
+++ b/backend/controllers/iepDetails.js
@@ -80,10 +80,12 @@ const getIepDetailsFactory = elite2Api => {
     const levels = await elite2Api.getAgencyIepLevels(context, agencyId)
 
     return sortPossibleIepLevelsAlphabetically(
-      levels.filter(level => level.iepDescription !== currentIepLevel).map(level => ({
-        title: level.iepDescription,
-        value: level.iepLevel,
-      }))
+      levels
+        .filter(level => level.iepDescription !== currentIepLevel && level.iepDescription !== 'Entry')
+        .map(level => ({
+          title: level.iepDescription,
+          value: level.iepLevel,
+        }))
     )
   }
 

--- a/backend/tests/iepDetails.test.js
+++ b/backend/tests/iepDetails.test.js
@@ -376,10 +376,6 @@ describe('IEP details controller', async () => {
         value: 'ENH',
       },
       {
-        title: 'Entry',
-        value: 'ENT',
-      },
-      {
         title: 'New level',
         value: 'NEW',
       },
@@ -403,10 +399,6 @@ describe('IEP details controller', async () => {
         value: 'ENH',
       },
       {
-        title: 'Entry',
-        value: 'ENT',
-      },
-      {
         title: 'New level',
         value: 'NEW',
       },
@@ -420,10 +412,6 @@ describe('IEP details controller', async () => {
       {
         title: 'Basic',
         value: 'BAS',
-      },
-      {
-        title: 'Entry',
-        value: 'ENT',
       },
       {
         title: 'New level',


### PR DESCRIPTION
For https://dsdmoj.atlassian.net/browse/NN-2103

We allowed them Entry before because it supported a few weird workflows. Estate policy is changing to not allow Entry to be set anymore, so we shouldn't show it on the Change IEP page.