### PR TITLE
NN-2139 - Fix duplicate row in activity list if there is no eventId

### DIFF
--- a/src/ResultsActivity/ResultsActivity.js
+++ b/src/ResultsActivity/ResultsActivity.js
@@ -329,7 +329,7 @@ class ResultsActivity extends Component {
           locationId,
           bookingId,
         } = mainEvent
-        const key = `${offenderNo}-${eventId}`
+        const key = `${offenderNo}-${eventId || index}`
 
         const offenderDetails = {
           offenderNo,


### PR DESCRIPTION
Fixes an issue where if there is no eventId and there are multiple rows for the same offender, the key is `offenderNo-undefined` which causes only 1 of the rows to be removed and the others to remain when content new lists are rendered. 

From what I can see, there's no other unique item to use and it appears to be that the missing `eventId` is likely to be only a dev data issue anyway, so `index` is our only option as the fallback, despite it being considered an anti-pattern.