### PR TITLE
NN-2121: Refresh page instead of updating state

### DIFF
--- a/src/ResultsActivity/ResultsActivity.js
+++ b/src/ResultsActivity/ResultsActivity.js
@@ -85,6 +85,7 @@ class ResultsActivity extends Component {
       period,
       handlePeriodChange,
       handlePrint,
+      getActivityList,
       activityData,
       sortOrder,
       orderField,
@@ -155,24 +156,11 @@ class ResultsActivity extends Component {
 
         const offenders = [...unpaidOffenders]
 
-        const response = await axios.post('/api/attendance/batch', {
+        await axios.post('/api/attendance/batch', {
           offenders,
         })
 
-        const findOffenderIndexByEventId = eventId => {
-          const offender = offenders.find(off => off.eventId === eventId)
-          return offender.offenderIndex
-        }
-
-        response.data.map(offender => {
-          const { paid, attended, eventId } = offender
-          const offenderAttendanceData = { paid, attended, pay: attended && paid }
-
-          setActivityOffenderAttendance(findOffenderIndexByEventId(eventId), offenderAttendanceData)
-
-          return offender
-        })
-
+        getActivityList()
         this.setState({ payingAll: false })
       } catch (error) {
         handleError(error)
@@ -439,6 +427,7 @@ ResultsActivity.propTypes = {
   handlePrint: PropTypes.func.isRequired,
   handlePeriodChange: PropTypes.func.isRequired,
   handleDateChange: PropTypes.func.isRequired,
+  getActivityList: PropTypes.func.isRequired,
   date: PropTypes.string.isRequired,
   period: PropTypes.string.isRequired,
   activityData: PropTypes.arrayOf(

--- a/src/ResultsActivity/ResultsActivity.test.js
+++ b/src/ResultsActivity/ResultsActivity.test.js
@@ -650,8 +650,6 @@ describe('Offender activity list results component', () => {
     expect(component.state().payingAll).toBe(true)
 
     await waitForAsync()
-
-    expect(props.setActivityOffenderAttendance).toHaveBeenCalledTimes(3)
     expect(component.state().payingAll).toBe(false)
   })
 })


### PR DESCRIPTION
When attending all/remaining prisoners, we are doing two loops - one loop which goes over all the offenders in the API response and calls the reducer, and then within the reducer another loop which loops over all of the offenders in state until it finds a match. When users are using the attend all functionality on pages with a lot of offenders (300), they are getting a 'something is making your browser slow' error due to the large amount of client-side processing.

Since this functionality is used on a large group of offenders at once, instead of updating state one by one, this PR proposes we simply refresh the activity list same way the page is loaded in the first place. As the attendances have been updated already through the batch API call, the returned data is equivalent to if we updated each state one by one without any client-side processing at all.