### PR TITLE
Nn 2109 update labels activity list

### DIFF
--- a/src/ResultsActivity/ResultsActivity.js
+++ b/src/ResultsActivity/ResultsActivity.js
@@ -149,6 +149,7 @@ class ResultsActivity extends Component {
     )
 
     const unpaidOffenders = new Set()
+    const totalOffenders = new Set()
 
     const attendAllNonAssigned = async () => {
       try {
@@ -309,6 +310,7 @@ class ResultsActivity extends Component {
             prisonId: agencyId,
             eventDate: date,
           })
+        totalOffenders.add(offenderNo)
 
         const { absentReason } = attendanceInfo || {}
         const otherActivitiesClasses = classNames({
@@ -401,7 +403,7 @@ class ResultsActivity extends Component {
             />
           </div>
           <StackedTotals>
-            <TotalResults label="Prisoners listed:" totalResults={activityData.length} />
+            <TotalResults label="Prisoners listed:" totalResults={totalOffenders.size} />
             <HideForPrint>
               <TotalResults label="Sessions attended:" totalResults={totalAttended} />
             </HideForPrint>

--- a/src/ResultsActivity/ResultsActivity.js
+++ b/src/ResultsActivity/ResultsActivity.js
@@ -98,7 +98,7 @@ class ResultsActivity extends Component {
       showModal,
       activityName,
       updateAttendanceEnabled,
-      totalPaid,
+      totalAttended,
       userRoles,
     } = this.props
 
@@ -186,14 +186,14 @@ class ResultsActivity extends Component {
 
     const showRemainingButton = activities => {
       const attendanceInfo = activities.filter(activity => activity.attendanceInfo)
-      return totalPaid !== 0 || attendanceInfo.length
+      return totalAttended !== 0 || attendanceInfo.length
     }
 
     const { payingAll } = this.state
 
     const batchControls = (
       <div id="batchControls" className="pure-u-md-12-12 padding-bottom">
-        {showAttendAllControl(activityData, totalPaid) &&
+        {showAttendAllControl(activityData, totalAttended) &&
           (payingAll ? (
             'Marking all as attended...'
           ) : (
@@ -403,7 +403,7 @@ class ResultsActivity extends Component {
           <StackedTotals>
             <TotalResults label="Prisoners listed:" totalResults={activityData.length} />
             <HideForPrint>
-              <TotalResults label="Prisoners paid:" totalResults={totalPaid} />
+              <TotalResults label="Sessions attended:" totalResults={totalAttended} />
             </HideForPrint>
             {activityHubUser && batchControls}
           </StackedTotals>
@@ -447,7 +447,7 @@ ResultsActivity.propTypes = {
       comment: PropTypes.string.isRequired,
     })
   ).isRequired,
-  totalPaid: PropTypes.number.isRequired,
+  totalAttended: PropTypes.number.isRequired,
   setColumnSort: PropTypes.func.isRequired,
   orderField: PropTypes.string.isRequired,
   sortOrder: PropTypes.string.isRequired,

--- a/src/ResultsActivity/ResultsActivity.test.js
+++ b/src/ResultsActivity/ResultsActivity.test.js
@@ -170,7 +170,7 @@ const props = {
   showModal: jest.fn(),
   activityName: 'Activity name',
   userRoles: ['ACTIVITY_HUB'],
-  totalPaid: 0,
+  totalAttended: 0,
 }
 
 describe('Offender activity list results component', () => {
@@ -456,20 +456,20 @@ describe('Offender activity list results component', () => {
 
   it('should display current total number of paid offenders', () => {
     const component = shallow(
-      <ResultsActivity {...props} totalPaid={1} activityData={response} date="07/06/2019" period="AM" />
+      <ResultsActivity {...props} totalAttended={1} activityData={response} date="07/06/2019" period="AM" />
     )
     expect(
       component
         .find('TotalResults')
         .at(1)
         .props()
-    ).toEqual({ label: 'Prisoners paid:', totalResults: 1 })
+    ).toEqual({ label: 'Sessions attended:', totalResults: 1 })
   })
 
   it('should not display pay all button if all prisoners are paid', () => {
     const today = moment().format('DD/MM/YYYY')
     const component = shallow(
-      <ResultsActivity {...props} totalPaid={4} activityData={response} date={today} period="AM" />
+      <ResultsActivity {...props} totalAttended={4} activityData={response} date={today} period="AM" />
     )
 
     const attendAllButton = component.find('#allAttendedButton')
@@ -481,7 +481,7 @@ describe('Offender activity list results component', () => {
       .subtract(8, 'days')
       .format('DD/MM/YYYY')
     const component = shallow(
-      <ResultsActivity {...props} totalPaid={0} activityData={response} date={isMoreThanAWeekOld} period="AM" />
+      <ResultsActivity {...props} totalAttended={0} activityData={response} date={isMoreThanAWeekOld} period="AM" />
     )
 
     const button = component.find('#allAttendedButton')
@@ -493,7 +493,7 @@ describe('Offender activity list results component', () => {
       .subtract(6, 'days')
       .format('DD/MM/YYYY')
     const component = shallow(
-      <ResultsActivity {...props} totalPaid={0} activityData={response} date={isInTheLastWeek} period="AM" />
+      <ResultsActivity {...props} totalAttended={0} activityData={response} date={isInTheLastWeek} period="AM" />
     )
 
     const button = component.find('#allAttendedButton')
@@ -505,7 +505,7 @@ describe('Offender activity list results component', () => {
       .add(1, 'days')
       .format('DD/MM/YYYY')
     const component = shallow(
-      <ResultsActivity {...props} totalPaid={0} activityData={response} date={tomorrow} period="AM" />
+      <ResultsActivity {...props} totalAttended={0} activityData={response} date={tomorrow} period="AM" />
     )
 
     const button = component.find('#allAttendedButton')
@@ -515,7 +515,7 @@ describe('Offender activity list results component', () => {
   it('should display "Attend all prisoners" button if no prisoners have been paid', () => {
     const today = moment().format('DD/MM/YYYY')
     const component = shallow(
-      <ResultsActivity {...props} totalPaid={0} activityData={response} date={today} period="AM" />
+      <ResultsActivity {...props} totalAttended={0} activityData={response} date={today} period="AM" />
     )
 
     const button = component.find('#allAttendedButton')
@@ -526,7 +526,7 @@ describe('Offender activity list results component', () => {
   it('should display "Attend all remaining prisoners" button if there are outstanding prisoners to pay', () => {
     const today = moment().format('DD/MM/YYYY')
     const component = shallow(
-      <ResultsActivity {...props} totalPaid={3} activityData={response} date={today} period="AM" />
+      <ResultsActivity {...props} totalAttended={3} activityData={response} date={today} period="AM" />
     )
 
     const button = component.find('#allAttendedButton')
@@ -574,7 +574,7 @@ describe('Offender activity list results component', () => {
 
     const today = moment().format('DD/MM/YYYY')
     const component = shallow(
-      <ResultsActivity {...props} totalPaid={0} activityData={otherAttendanceData} date={today} period="AM" />
+      <ResultsActivity {...props} totalAttended={0} activityData={otherAttendanceData} date={today} period="AM" />
     )
 
     const button = component.find('#allAttendedButton')
@@ -615,7 +615,7 @@ describe('Offender activity list results component', () => {
 
     const today = moment().format('DD/MM/YYYY')
     const component = shallow(
-      <ResultsActivity {...props} totalPaid={0} activityData={otherAttendanceNull} date={today} period="AM" />
+      <ResultsActivity {...props} totalAttended={0} activityData={otherAttendanceNull} date={today} period="AM" />
     )
 
     const button = component.find('#allAttendedButton')
@@ -626,7 +626,7 @@ describe('Offender activity list results component', () => {
   it('should call the attendAll function when the link is clicked', async () => {
     const today = moment().format('DD/MM/YYYY')
     const component = shallow(
-      <ResultsActivity {...props} totalPaid={0} activityData={response} date={today} period="AM" />
+      <ResultsActivity {...props} totalAttended={0} activityData={response} date={today} period="AM" />
     )
 
     const attendAllButton = component.find('#allAttendedButton')

--- a/src/ResultsActivity/ResultsActivityContainer.js
+++ b/src/ResultsActivity/ResultsActivityContainer.js
@@ -225,7 +225,7 @@ const mapStateToProps = state => ({
   orderField: state.events.orderField,
   sortOrder: state.events.sortOrder,
   updateAttendanceEnabled: state.flags.updateAttendanceEnabled,
-  totalPaid: state.events.totalPaid,
+  totalAttended: state.events.totalAttended,
   userRoles: state.app.user.roles,
 })
 

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -28,6 +28,14 @@ const countPaid = data =>
     .map(event => (event && event.attendanceInfo && event.attendanceInfo.paid ? 1 : 0))
     .reduce((acc, current) => acc + current, 0)
 
+const countAttended = data =>
+  data
+    .map(
+      event =>
+        event && event.attendanceInfo && event.attendanceInfo.paid && !event.attendanceInfo.absentReason ? 1 : 0
+    )
+    .reduce((acc, current) => acc + current, 0)
+
 const getHouseBlockMainActivities = houseBlockData =>
   houseBlockData
     .map(data => data.activities)
@@ -227,7 +235,7 @@ export function events(state = eventsInitialState, action) {
     case ActionTypes.SET_ACTIVITY_DATA:
       return {
         ...state,
-        totalPaid: countPaid(action.data),
+        totalAttended: countAttended(action.data),
         activityData: action.data,
       }
     case ActionTypes.SET_ABSENT_REASONS:
@@ -266,7 +274,7 @@ export function events(state = eventsInitialState, action) {
 
       return {
         ...state,
-        totalPaid: countPaid(activityData),
+        totalAttended: countAttended(activityData),
         activityData,
       }
     }

--- a/src/redux/reducers/reducers.test.js
+++ b/src/redux/reducers/reducers.test.js
@@ -396,7 +396,7 @@ describe('app (global) reducer', () => {
       })
     ).toEqual({
       ...eventsInitialState,
-      totalPaid: 0,
+      totalAttended: 0,
       activityData: [
         { offenderNo: 'A1' },
         {


### PR DESCRIPTION
For https://dsdmoj.atlassian.net/browse/NN-2109

This changes the 'Prisoners paid' label on the activity list to now say 'Sessions attended'. It also changes what this session represents from all paid activities to all paid activities without an absence reason, so all who attended.

It also changes what the 'Prisoners listed' label represents, from a count of all main activities on the page to a count of all the unique prisoners.