### PR TITLE
Nn 2055 fix eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,7 @@
     ],
     "prettier/prettier": ["error"],
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-    "react/jsx-props-no-spreading": 1,
+    "react/jsx-props-no-spreading": 0, // disable as AirBnb says sparce usage is okay, and we mostly use in tests
     "no-underscore-dangle": ["error", { "allow": ["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] }],
     "no-param-reassign": [2, { "props": true }],
     "import/no-named-as-default": 0, // disable as we use connected components

--- a/.eslintrc
+++ b/.eslintrc
@@ -26,7 +26,6 @@
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/jsx-props-no-spreading": 1,
     "react/prop-types": 1,
-    "react/require-default-props": 1,
     "jsx-a11y/control-has-associated-label": 1,
     "no-underscore-dangle": ["error", { "allow": ["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] }],
     "no-param-reassign": [2, { "props": true }],

--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,6 @@
     "prettier/prettier": ["error"],
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/jsx-props-no-spreading": 1,
-    "react/prop-types": 1,
     "jsx-a11y/control-has-associated-label": 1,
     "no-underscore-dangle": ["error", { "allow": ["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] }],
     "no-param-reassign": [2, { "props": true }],

--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,6 @@
     "prettier/prettier": ["error"],
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/jsx-props-no-spreading": 1,
-    "jsx-a11y/control-has-associated-label": 1,
     "no-underscore-dangle": ["error", { "allow": ["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] }],
     "no-param-reassign": [2, { "props": true }],
     "import/no-named-as-default": 0, // disable as we use connected components

--- a/src/Adjudications/AdjudicationDetail/AdjudicationDetail.styles.js
+++ b/src/Adjudications/AdjudicationDetail/AdjudicationDetail.styles.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { spacing } from '@govuk-react/lib'
 
@@ -36,3 +37,18 @@ export const GridContainer = styled.div`
   ${({ includeTrailingDivider }) => includeTrailingDivider && `border-bottom: 1px solid ${GREY}`};
   margin-top: ${spacing.simple(2)}px;
 `
+
+LabelAndValue.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.number.isRequired,
+}
+
+Location.propTypes = {
+  establishment: PropTypes.string,
+  interiorLocation: PropTypes.string,
+}
+
+Location.defaultProps = {
+  interiorLocation: '',
+  establishment: '',
+}

--- a/src/Adjudications/AdjudicationDetail/Awards.js
+++ b/src/Adjudications/AdjudicationDetail/Awards.js
@@ -56,6 +56,10 @@ Awards.propTypes = {
   ),
 }
 
+Awards.defaultProps = {
+  awards: [],
+}
+
 const mapStateToProps = ({
   adjudicationHistory: {
     detail: { sanctions },

--- a/src/Adjudications/AdjudicationDetail/Detail.js
+++ b/src/Adjudications/AdjudicationDetail/Detail.js
@@ -56,7 +56,7 @@ Detail.propTypes = {
     interiorLocation: PropTypes.string,
     reportNumber: PropTypes.number,
     reporterName: PropTypes.string,
-    reporterTime: PropTypes.string,
+    reportTime: PropTypes.string,
   }),
 }
 

--- a/src/Adjudications/AdjudicationDetail/Hearing.js
+++ b/src/Adjudications/AdjudicationDetail/Hearing.js
@@ -56,6 +56,10 @@ Hearing.propTypes = {
   }),
 }
 
+Hearing.defaultProps = {
+  hearing: null,
+}
+
 const mapStateToProps = ({
   adjudicationHistory: {
     detail: { hearing },

--- a/src/Adjudications/AdjudicationDetail/Hearing.js
+++ b/src/Adjudications/AdjudicationDetail/Hearing.js
@@ -57,7 +57,7 @@ Hearing.propTypes = {
 }
 
 Hearing.defaultProps = {
-  hearing: null,
+  hearing: undefined,
 }
 
 const mapStateToProps = ({

--- a/src/Adjudications/AdjudicationDetail/Results.js
+++ b/src/Adjudications/AdjudicationDetail/Results.js
@@ -52,6 +52,10 @@ Results.propTypes = {
   ),
 }
 
+Results.defaultProps = {
+  results: [],
+}
+
 const mapStateToProps = ({
   adjudicationHistory: {
     detail: { results },

--- a/src/Adjudications/AdjudicationHistory/AdjudicationHistoryForm.js
+++ b/src/Adjudications/AdjudicationHistory/AdjudicationHistoryForm.js
@@ -145,6 +145,29 @@ AdjudicationHistoryForm.propTypes = {
   }).isRequired,
 }
 
+FormFields.propTypes = {
+  now: PropTypes.instanceOf(moment).isRequired,
+  errors: PropTypes.arrayOf(PropTypes.shape({})),
+  submitting: PropTypes.bool.isRequired,
+  agencies: PropTypes.arrayOf(
+    PropTypes.shape({
+      agencyId: PropTypes.string.isRequired,
+      agencyType: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired,
+    }).isRequired
+  ).isRequired,
+  values: PropTypes.shape({
+    establishment: PropTypes.string,
+    fromDate: PropTypes.instanceOf(moment),
+    toDate: PropTypes.instanceOf(moment),
+  }).isRequired,
+  reset: PropTypes.func.isRequired,
+}
+
+FormFields.defaultProps = {
+  errors: [],
+}
+
 const mapStateToProps = state => ({
   now: state.adjudicationHistory.now,
   agencies: state.adjudicationHistory.agencies,

--- a/src/AlertFlags/AlertFlags.js
+++ b/src/AlertFlags/AlertFlags.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import './AlertFlags.scss'
 

--- a/src/App.js
+++ b/src/App.js
@@ -497,7 +497,7 @@ class App extends React.Component {
           <Route
             exact
             path={routePaths.prisonersUnaccountedFor}
-            render={({ history, match: { params } }) => (
+            render={({ history }) => (
               <PrisonersUnaccountedForContainer
                 handleDateChange={event => this.handleDateChange(event)}
                 handlePeriodChange={event => this.handlePeriodChange(event)}

--- a/src/App.js
+++ b/src/App.js
@@ -616,6 +616,8 @@ App.propTypes = {
     mailTo: PropTypes.string,
     googleAnalyticsId: PropTypes.string,
     licencesUrl: PropTypes.string,
+    flags: PropTypes.objectOf(PropTypes.string),
+    updateAttendancePrisons: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
   date: PropTypes.string.isRequired,
   error: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({ message: PropTypes.string })]),

--- a/src/Attendance/AttendanceOptions/AttendanceOptions.js
+++ b/src/Attendance/AttendanceOptions/AttendanceOptions.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import axios from 'axios'
 import Radio from '@govuk-react/radio'

--- a/src/Attendance/AttendanceOptions/AttendanceOptions.js
+++ b/src/Attendance/AttendanceOptions/AttendanceOptions.js
@@ -190,6 +190,7 @@ function AttendanceOptions({
 AttendanceOptions.propTypes = {
   offenderDetails: PropTypes.shape({
     offenderNo: PropTypes.string,
+    bookingId: PropTypes.string,
     firstName: PropTypes.string,
     lastName: PropTypes.string,
     eventId: PropTypes.number,

--- a/src/Attendance/AttendanceOtherForm/AttendanceOtherForm.js
+++ b/src/Attendance/AttendanceOtherForm/AttendanceOtherForm.js
@@ -182,11 +182,25 @@ AttendanceOtherForm.propTypes = {
   absentReasons: PropTypes.shape({
     paidReasons: PropTypes.arrayOf(PropTypes.shape({ value: PropTypes.string, name: PropTypes.string })).isRequired,
     unpaidReasons: PropTypes.arrayOf(PropTypes.shape({ value: PropTypes.string, name: PropTypes.string })).isRequired,
+    triggersIEPWarning: PropTypes.arrayOf(PropTypes.string).isRequired,
   }).isRequired,
 
   // props
-  offender: PropTypes.shape({ id: PropTypes.string, firstName: PropTypes.string, lastName: PropTypes.string })
-    .isRequired,
+  offender: PropTypes.shape({
+    offenderIndex: PropTypes.number,
+    firstName: PropTypes.string,
+    lastName: PropTypes.string,
+    bookingId: PropTypes.string,
+    offenderNo: PropTypes.string,
+    eventId: PropTypes.string,
+    eventLocationId: PropTypes.string,
+    attendanceInfo: PropTypes.shape({
+      paid: PropTypes.bool,
+      absentReason: PropTypes.string,
+      id: PropTypes.number,
+      comments: PropTypes.string,
+    }),
+  }).isRequired,
   updateOffenderAttendance: PropTypes.func.isRequired,
   showModal: PropTypes.func.isRequired,
   activityName: PropTypes.string.isRequired,

--- a/src/BulkAppointments/AddPrisoners/AddPrisonersContainer.js
+++ b/src/BulkAppointments/AddPrisoners/AddPrisonersContainer.js
@@ -172,6 +172,7 @@ AddPrisonerContainer.propTypes = {
   setLoadedDispatch: PropTypes.func.isRequired,
   history: PropTypes.shape({
     replace: PropTypes.func.isRequired,
+    push: PropTypes.func.isRequired,
   }).isRequired,
   dispatchAppointmentPrisoners: PropTypes.func.isRequired,
   dispatchBulkAppointmentsComplete: PropTypes.func.isRequired,

--- a/src/BulkAppointments/AppointmentDetailsForm/AppointmentDetailsContainer.js
+++ b/src/BulkAppointments/AppointmentDetailsForm/AppointmentDetailsContainer.js
@@ -55,6 +55,7 @@ AppointmentDetailsFormContainer.propTypes = {
   dispatchAppointmentDetails: PropTypes.func.isRequired,
   history: PropTypes.shape({
     replace: PropTypes.func.isRequired,
+    push: PropTypes.func.isRequired,
   }).isRequired,
 }
 

--- a/src/Components/ModalContainer/ModalContainer.js
+++ b/src/Components/ModalContainer/ModalContainer.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import Modal from 'react-modal'
+import PropTypes from 'prop-types'
 
 const StyledModal = styled(Modal)`
   background: rgb(255, 255, 255);
@@ -48,6 +49,11 @@ const ModalContainer = ({ isOpen, showModal, ...props }) => {
       {...props}
     />
   )
+}
+
+ModalContainer.propTypes = {
+  isOpen: PropTypes.func.isRequired,
+  showModal: PropTypes.func.isRequired,
 }
 
 export default ModalContainer

--- a/src/Components/Page/Page.js
+++ b/src/Components/Page/Page.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { H1 } from '@govuk-react/heading'

--- a/src/Components/RadioGroup/RadioGroup.js
+++ b/src/Components/RadioGroup/RadioGroup.js
@@ -27,7 +27,9 @@ RadioGroup.defaultProps = {
 }
 
 RadioGroup.propTypes = {
-  input: PropTypes.shape({}),
+  input: PropTypes.shape({
+    value: PropTypes.string,
+  }),
   meta: PropTypes.shape({}),
   label: PropTypes.string,
   hint: PropTypes.string,

--- a/src/CreateAlert/CreateAlertContainer.js
+++ b/src/CreateAlert/CreateAlertContainer.js
@@ -115,11 +115,13 @@ CreateAlertContainer.propTypes = {
   offenderDetails: PropTypes.shape({
     firstName: PropTypes.string,
     lastName: PropTypes.string,
+    bookingId: PropTypes.number,
   }).isRequired,
   handleError: PropTypes.func.isRequired,
   raiseAnalyticsEvent: PropTypes.func.isRequired,
   history: PropTypes.shape({
     replace: PropTypes.func.isRequired,
+    goBack: PropTypes.func.isRequired,
   }).isRequired,
   resetErrorDispatch: PropTypes.func.isRequired,
   setLoadedDispatch: PropTypes.func.isRequired,

--- a/src/CurrentlyOut/CurrentlyOut.js
+++ b/src/CurrentlyOut/CurrentlyOut.js
@@ -23,6 +23,7 @@ const CurrentlyOut = ({ rows, sortOrder, setColumnSort }) => (
     <table className="currently-out">
       <thead>
         <tr>
+          {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
           <th className="straight width10" />
           <th className="straight width10">
             <SortableColumn

--- a/src/CurrentlyOut/CurrentlyOutContainer.js
+++ b/src/CurrentlyOut/CurrentlyOutContainer.js
@@ -77,6 +77,7 @@ class CurrentlyOutContainer extends Component {
 CurrentlyOutContainer.propTypes = {
   dataFetcher: PropTypes.func.isRequired,
   handleError: PropTypes.func.isRequired,
+  setLoadedDispatch: PropTypes.func.isRequired,
   // history from Redux Router Route
   history: PropTypes.shape({
     replace: PropTypes.func.isRequired,

--- a/src/DatePickers/FormDatePicker.js
+++ b/src/DatePickers/FormDatePicker.js
@@ -56,6 +56,7 @@ class FormDatePicker extends Component {
 FormDatePicker.propTypes = {
   shouldShowDay: PropTypes.func.isRequired,
   placeholder: PropTypes.string,
+  label: PropTypes.string,
   meta: PropTypes.shape({
     touched: PropTypes.bool,
     error: PropTypes.string,
@@ -69,6 +70,7 @@ FormDatePicker.propTypes = {
 
 FormDatePicker.defaultProps = {
   placeholder: '',
+  label: '',
   meta: {},
 }
 

--- a/src/DatePickers/__snapshots__/FormDatePicker.test.js.snap
+++ b/src/DatePickers/__snapshots__/FormDatePicker.test.js.snap
@@ -12,6 +12,7 @@ exports[`Form date picker should render correctly 1`] = `
         className="sc-bdVaJa fqDsBO"
       >
          
+        
          
       </span>
       <span

--- a/src/EnRoute/EnRoute.js
+++ b/src/EnRoute/EnRoute.js
@@ -21,6 +21,7 @@ const EnRoute = ({ rows, sortOrder, setColumnSort }) => (
     <table>
       <thead>
         <tr>
+          {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
           <th className="straight width10" />
           <th className="straight width15">
             <SortableColumn

--- a/src/EnRoute/EnRouteContainer.js
+++ b/src/EnRoute/EnRouteContainer.js
@@ -71,6 +71,7 @@ EnRouteContainer.propTypes = {
   agencyId: PropTypes.string.isRequired,
   caseLoadOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
   resetErrorDispatch: PropTypes.func.isRequired,
+  setLoadedDispatch: PropTypes.func.isRequired,
 }
 
 const mapStateToProps = state => ({

--- a/src/GlobalSearch/GlobalSearchContainer.js
+++ b/src/GlobalSearch/GlobalSearchContainer.js
@@ -233,6 +233,7 @@ GlobalSearchContainer.propTypes = {
       latestLocation: PropTypes.string.isRequired,
     })
   ).isRequired,
+  userRoles: PropTypes.arrayOf(PropTypes.string).isRequired,
   pageNumber: PropTypes.number.isRequired,
   pageSize: PropTypes.number.isRequired,
   totalRecords: PropTypes.number.isRequired,

--- a/src/GlobalSearch/GlobalSearchForm.js
+++ b/src/GlobalSearch/GlobalSearchForm.js
@@ -176,10 +176,13 @@ GlobalSearchForm.propTypes = {
   handleSearchTextChange: PropTypes.func.isRequired,
   handleSearchGenderFilterChange: PropTypes.func.isRequired,
   handleSearchLocationFilterChange: PropTypes.func.isRequired,
+  handleDateOfBirthChange: PropTypes.func.isRequired,
+  showErrors: PropTypes.func.isRequired,
   clearFilters: PropTypes.func.isRequired,
   searchText: PropTypes.string.isRequired,
   locationFilter: PropTypes.string.isRequired,
   genderFilter: PropTypes.string.isRequired,
+  searchPerformed: PropTypes.bool.isRequired,
   history: ReactRouterPropTypes.history.isRequired,
 }
 

--- a/src/GlobalSearch/GlobalSearchResultList.js
+++ b/src/GlobalSearch/GlobalSearchResultList.js
@@ -23,12 +23,14 @@ const GlobalSearchResultList = ({
 }) => {
   const headings = (
     <tr>
+      {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
       <th className="straight" />
       <th className="straight">Name</th>
       <th className="straight">Prison&nbsp;no.</th>
       <th className="straight">Date of birth</th>
       <th className="straight">Location</th>
       <th className="straight">Actual working name</th>
+      {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
       {licencesUser && <th className="straight" />}
     </tr>
   )

--- a/src/IEPCreated/IEPCreated.js
+++ b/src/IEPCreated/IEPCreated.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { H1 } from '@govuk-react/heading'

--- a/src/IEPCreated/IEPCreated.js
+++ b/src/IEPCreated/IEPCreated.js
@@ -70,7 +70,12 @@ const IEPCreated = ({ showModal, offender, iepValues, activityName, user }) => {
 IEPCreated.propTypes = {
   user: userType.isRequired,
   showModal: PropTypes.func.isRequired,
-  offender: PropTypes.shape({}).isRequired,
+  offender: PropTypes.shape({
+    offenderNo: PropTypes.string,
+    firstName: PropTypes.string,
+    lastName: PropTypes.string,
+    cellLocation: PropTypes.string,
+  }).isRequired,
   activityName: PropTypes.string.isRequired,
   iepValues: PropTypes.shape({
     pay: PropTypes.string,

--- a/src/IepDetails/CurrentIepLevel.js
+++ b/src/IepDetails/CurrentIepLevel.js
@@ -41,6 +41,7 @@ CurrentIepLevel.propTypes = {
   nextReviewDate: PropTypes.string,
   history: PropTypes.shape({
     replace: PropTypes.func.isRequired,
+    push: PropTypes.func.isRequired,
   }).isRequired,
   userCanMaintainIep: PropTypes.bool.isRequired,
 }

--- a/src/IepDetails/IepChangeContainer.js
+++ b/src/IepDetails/IepChangeContainer.js
@@ -125,6 +125,7 @@ IepChangeContainer.defaultProps = {
 IepChangeContainer.propTypes = {
   offenderNo: PropTypes.string,
   currentIepLevel: PropTypes.string,
+  activeCaseLoadId: PropTypes.string.isRequired,
   offenderDetails: PropTypes.shape({
     firstName: PropTypes.string,
     lastName: PropTypes.string,
@@ -142,6 +143,7 @@ IepChangeContainer.propTypes = {
   // history from Redux Router Route
   history: PropTypes.shape({
     replace: PropTypes.func.isRequired,
+    goBack: PropTypes.func.isRequired,
   }).isRequired,
 
   // redux dispatch

--- a/src/IepDetails/IepHistoryForm.js
+++ b/src/IepDetails/IepHistoryForm.js
@@ -160,9 +160,29 @@ IepHistoryForm.propTypes = {
   }).isRequired,
 }
 
+FormFields.propTypes = {
+  now: PropTypes.instanceOf(moment).isRequired,
+  reset: PropTypes.func.isRequired,
+  establishments: PropTypes.arrayOf(
+    PropTypes.shape({
+      agencyId: PropTypes.string.isRequired,
+      agencyType: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired,
+    }).isRequired
+  ).isRequired,
+  values: PropTypes.shape({
+    iepEstablishment: PropTypes.string,
+    iepLevel: PropTypes.string,
+    fromDate: PropTypes.instanceOf(moment),
+    toDate: PropTypes.instanceOf(moment),
+  }).isRequired,
+  levels: PropTypes.arrayOf(PropTypes.string).isRequired,
+  submitting: PropTypes.bool.isRequired,
+  errors: PropTypes.arrayOf(PropTypes.shape({})),
+}
+
 FormFields.defaultProps = {
-  establishments: [],
-  levels: [],
+  errors: [],
 }
 
 const mapStateToProps = state => ({

--- a/src/InReception/InReception.js
+++ b/src/InReception/InReception.js
@@ -21,6 +21,7 @@ const InReception = ({ sortOrder, setColumnSort, rows }) => (
     <table>
       <thead>
         <tr>
+          {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
           <th className="straight width10" />
           <th className="straight width15">
             <SortableColumn

--- a/src/InReception/InReceptionContainer.js
+++ b/src/InReception/InReceptionContainer.js
@@ -66,7 +66,11 @@ InReceptionContainer.propTypes = {
   agencyId: PropTypes.string.isRequired,
   history: PropTypes.shape({
     replace: PropTypes.func.isRequired,
+    push: PropTypes.func.isRequired,
   }).isRequired,
+  resetErrorDispatch: PropTypes.func.isRequired,
+  setLoadedDispatch: PropTypes.func.isRequired,
+  handleError: PropTypes.func.isRequired,
 }
 
 const mapStateToProps = state => ({

--- a/src/MovementsIn/MovementsIn.js
+++ b/src/MovementsIn/MovementsIn.js
@@ -32,6 +32,7 @@ const MovementsIn = ({ rows, sortOrder, setColumnSort, agencyId }) => (
     <table>
       <thead>
         <tr>
+          {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
           <th className="straight width10" />
           <th className="straight width10">
             <SortableColumn

--- a/src/MovementsIn/MovementsInContainer.js
+++ b/src/MovementsIn/MovementsInContainer.js
@@ -69,6 +69,7 @@ MovementsInContainer.propTypes = {
 
   agencyId: PropTypes.string.isRequired,
   resetErrorDispatch: PropTypes.func.isRequired,
+  setLoadedDispatch: PropTypes.func.isRequired,
 }
 
 const mapStateToProps = state => ({

--- a/src/MovementsOut/MovementsOut.js
+++ b/src/MovementsOut/MovementsOut.js
@@ -21,6 +21,7 @@ const MovementsOut = ({ rows, sortOrder, setColumnSort }) => (
     <table>
       <thead>
         <tr>
+          {/* eslint-disable-next-line jsx-a11y/control-has-associated-label */}
           <th className="straight width5" />
           <th className="straight width15">
             <SortableColumn

--- a/src/MovementsOut/MovementsOutContainer.js
+++ b/src/MovementsOut/MovementsOutContainer.js
@@ -64,8 +64,10 @@ MovementsOutContainer.propTypes = {
   handleError: PropTypes.func.isRequired,
   agencyId: PropTypes.string.isRequired,
   resetErrorDispatch: PropTypes.func.isRequired,
+  setLoadedDispatch: PropTypes.func.isRequired,
   history: PropTypes.shape({
     replace: PropTypes.func.isRequired,
+    push: PropTypes.func.isRequired,
   }).isRequired,
 }
 

--- a/src/PrisonersUnaccountedFor/PrisonersUnaccountedForSearch.js
+++ b/src/PrisonersUnaccountedFor/PrisonersUnaccountedForSearch.js
@@ -116,6 +116,7 @@ const PrisonersUnaccountedForSearch = ({
 PrisonersUnaccountedForSearch.propTypes = {
   handlePeriodChange: PropTypes.func.isRequired,
   handleDateChange: PropTypes.func.isRequired,
+  reloadPage: PropTypes.func.isRequired,
   date: PropTypes.string.isRequired,
   period: PropTypes.string.isRequired,
   setColumnSort: PropTypes.func.isRequired,

--- a/src/ResultsActivity/ResultsActivityContainer.js
+++ b/src/ResultsActivity/ResultsActivityContainer.js
@@ -189,6 +189,9 @@ ResultsActivityContainer.propTypes = {
   handlePeriodChange: PropTypes.func.isRequired,
   handleDateChange: PropTypes.func.isRequired,
   showModal: PropTypes.func.isRequired,
+  getAbsentReasonsDispatch: PropTypes.func.isRequired,
+  setOffenderPaymentDataDispatch: PropTypes.func.isRequired,
+  updateAttendanceEnabled: PropTypes.bool.isRequired,
 
   // mapStateToProps
   activity: PropTypes.string.isRequired,

--- a/src/ResultsHouseblock/ResultsHouseblock.js
+++ b/src/ResultsHouseblock/ResultsHouseblock.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import Link from '@govuk-react/link'
 import { Link as RouterLink } from 'react-router-dom'
 import Button from '@govuk-react/button'

--- a/src/ResultsHouseblock/ResultsHouseblock.js
+++ b/src/ResultsHouseblock/ResultsHouseblock.js
@@ -438,6 +438,8 @@ ResultsHouseblock.propTypes = {
   sortOrder: PropTypes.string.isRequired,
   update: PropTypes.func.isRequired,
   handleError: PropTypes.func.isRequired,
+  resetErrorDispatch: PropTypes.func.isRequired,
+  raiseAnalyticsEvent: PropTypes.func.isRequired,
   setHouseblockOffenderAttendance: PropTypes.func.isRequired,
   showModal: PropTypes.func.isRequired,
   activityName: PropTypes.string.isRequired,

--- a/src/ResultsHouseblock/ResultsHouseblockContainer.js
+++ b/src/ResultsHouseblock/ResultsHouseblockContainer.js
@@ -229,11 +229,14 @@ ResultsHouseblockContainer.propTypes = {
   handleDateChange: PropTypes.func.isRequired,
   handlePeriodChange: PropTypes.func.isRequired,
   showModal: PropTypes.func.isRequired,
+  updateAttendanceEnabled: PropTypes.bool.isRequired,
 
   // mapStateToProps
   agencyId: PropTypes.string.isRequired,
   currentLocation: PropTypes.string.isRequired,
   currentSubLocation: PropTypes.string.isRequired,
+  houseblockData: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  locations: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   date: PropTypes.string.isRequired,
   period: PropTypes.string.isRequired,
   loaded: PropTypes.bool.isRequired,
@@ -249,6 +252,8 @@ ResultsHouseblockContainer.propTypes = {
   setLoadedDispatch: PropTypes.func.isRequired,
   sortOrderDispatch: PropTypes.func.isRequired,
   subLocationDispatch: PropTypes.func.isRequired,
+  setOffenderPaymentDataDispatch: PropTypes.func.isRequired,
+  getAbsentReasonsDispatch: PropTypes.func.isRequired,
 
   // special
   history: ReactRouterPropTypes.history.isRequired,

--- a/src/Search/Search.js
+++ b/src/Search/Search.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import '../index.scss'
 import './search.scss'
 import PropTypes from 'prop-types'

--- a/src/final-form-govuk-helpers.js
+++ b/src/final-form-govuk-helpers.js
@@ -44,6 +44,15 @@ WhenFieldChanges.propTypes = {
   to: PropTypes.string.isRequired,
 }
 
+FieldWithError.propTypes = {
+  name: PropTypes.string.isRequired,
+  errors: PropTypes.arrayOf(PropTypes.shape({})),
+}
+
+FieldWithError.defaultProps = {
+  errors: [],
+}
+
 export { WhenFieldChanges }
 
 export const onHandleErrorClick = targetName => {


### PR DESCRIPTION
Most rule violations have been fixed. The only two that have been disabled are:
`jsx-a11y/control-has-associated-label` only on empty `<th>` elements which we use for table layout.
`react/jsx-props-no-spreading` the AirBnb style guide mentions prop spreading as something to use sparingly. We don't exactly follow that philosophy (over 150 warnings), but they are mostly in test files. Disabled as it's not considered evil.