### PR TITLE
NN-2173 Add nunjucks filters for getting date and time from string

### DIFF
--- a/backend/utils.js
+++ b/backend/utils.js
@@ -1,4 +1,5 @@
 const moment = require('moment')
+const { DATE_TIME_FORMAT_SPEC } = require('../src/dateHelpers')
 
 const switchDateFormat = (displayDate, format = 'DD/MM/YYYY') => {
   if (displayDate) {
@@ -156,6 +157,20 @@ const flagFuturePeriodSelected = (date, period, currentPeriod) => {
   return false
 }
 
+const isValidDateTimeFormat = dateTimeString => moment(dateTimeString, DATE_TIME_FORMAT_SPEC, true).isValid()
+
+const getDate = dateTimeString => {
+  if (!isValidDateTimeFormat(dateTimeString)) return 'Invalid date'
+
+  return moment(dateTimeString, DATE_TIME_FORMAT_SPEC).format('dddd D MMMM YYYY')
+}
+
+const getTime = dateTimeString => {
+  if (!isValidDateTimeFormat(dateTimeString)) return 'Invalid time'
+
+  return moment(dateTimeString, DATE_TIME_FORMAT_SPEC).format('HH:mm')
+}
+
 module.exports = {
   isToday,
   isTodayOrAfter,
@@ -179,4 +194,6 @@ module.exports = {
   flagFuturePeriodSelected,
   readablePeriod,
   readableDateFormat,
+  getDate,
+  getTime,
 }

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -160,13 +160,13 @@ const flagFuturePeriodSelected = (date, period, currentPeriod) => {
 const isValidDateTimeFormat = dateTimeString => moment(dateTimeString, DATE_TIME_FORMAT_SPEC, true).isValid()
 
 const getDate = dateTimeString => {
-  if (!isValidDateTimeFormat(dateTimeString)) return 'Invalid date'
+  if (!isValidDateTimeFormat(dateTimeString)) return 'Invalid date or time'
 
   return moment(dateTimeString, DATE_TIME_FORMAT_SPEC).format('dddd D MMMM YYYY')
 }
 
 const getTime = dateTimeString => {
-  if (!isValidDateTimeFormat(dateTimeString)) return 'Invalid time'
+  if (!isValidDateTimeFormat(dateTimeString)) return 'Invalid date or time'
 
   return moment(dateTimeString, DATE_TIME_FORMAT_SPEC).format('HH:mm')
 }

--- a/backend/utils.test.js
+++ b/backend/utils.test.js
@@ -13,6 +13,8 @@ import {
   flagFuturePeriodSelected,
   readablePeriod,
   isViewableFlag,
+  getDate,
+  getTime,
 } from './utils'
 
 describe('capitalize()', () => {
@@ -278,5 +280,33 @@ describe('isViewableFlag', () => {
 
   it('should not allow any non specified alerts to be a viewable flag', () => {
     expect(isViewableFlag('ROH')).toBe(false)
+  })
+})
+
+describe('getDate()', () => {
+  it('should return the correctly formatted date only', () => {
+    expect(getDate('2019-09-23T15:30:00')).toEqual('Monday 23 September 2019')
+  })
+
+  it('should return Invalid date if invalid string is used', () => {
+    expect(getDate('2019-13-23')).toEqual('Invalid date')
+  })
+
+  it('should return Invalid date if no date time string is used', () => {
+    expect(getDate()).toEqual('Invalid date')
+  })
+})
+
+describe('getTime()', () => {
+  it('should return the correctly formatted time only', () => {
+    expect(getTime('2019-09-23T15:30:00')).toEqual('15:30')
+  })
+
+  it('should return Invalid time if invalid string is used', () => {
+    expect(getTime('2019-13-23')).toEqual('Invalid time')
+  })
+
+  it('should return Invalid time if no date time string is used', () => {
+    expect(getTime()).toEqual('Invalid time')
   })
 })

--- a/backend/utils.test.js
+++ b/backend/utils.test.js
@@ -288,12 +288,12 @@ describe('getDate()', () => {
     expect(getDate('2019-09-23T15:30:00')).toEqual('Monday 23 September 2019')
   })
 
-  it('should return Invalid date if invalid string is used', () => {
-    expect(getDate('2019-13-23')).toEqual('Invalid date')
+  it('should return Invalid message if invalid string is used', () => {
+    expect(getDate('2019-13-23')).toEqual('Invalid date or time')
   })
 
-  it('should return Invalid date if no date time string is used', () => {
-    expect(getDate()).toEqual('Invalid date')
+  it('should return Invalid message if no date time string is used', () => {
+    expect(getDate()).toEqual('Invalid date or time')
   })
 })
 
@@ -302,11 +302,11 @@ describe('getTime()', () => {
     expect(getTime('2019-09-23T15:30:00')).toEqual('15:30')
   })
 
-  it('should return Invalid time if invalid string is used', () => {
-    expect(getTime('2019-13-23')).toEqual('Invalid time')
+  it('should return Invalid message if invalid string is used', () => {
+    expect(getTime('2019-13-23')).toEqual('Invalid date or time')
   })
 
-  it('should return Invalid time if no date time string is used', () => {
-    expect(getTime()).toEqual('Invalid time')
+  it('should return Invalid message if no date time string is used', () => {
+    expect(getTime()).toEqual('Invalid date or time')
   })
 })

--- a/backend/utils/nunjucksSetup.js
+++ b/backend/utils/nunjucksSetup.js
@@ -1,5 +1,6 @@
 const nunjucks = require('nunjucks')
 const config = require('../config')
+const { getDate, getTime } = require('../utils')
 
 module.exports = (app, path) => {
   const njkEnv = nunjucks.configure([path.join(__dirname, '../../views'), 'node_modules/govuk-frontend/'], {
@@ -16,6 +17,7 @@ module.exports = (app, path) => {
     }
     return null
   })
-
+  njkEnv.addFilter('getDate', getDate)
+  njkEnv.addFilter('getTime', getTime)
   njkEnv.addGlobal('notmUrl', config.app.notmEndpointUrl)
 }

--- a/package.json
+++ b/package.json
@@ -179,10 +179,6 @@
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],
-    "testMatch": [
-      "<rootDir>/src/**/__tests__/**/*.{js,jsx,mjs}",
-      "<rootDir>/(src|backend)/**/?(*.)(spec|test).{js,jsx,mjs}"
-    ],
     "testEnvironment": "node",
     "testURL": "http://localhost",
     "transform": {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -95,7 +95,7 @@ describe('App component', () => {
   describe('session timeouts', () => {
     const component = shallow(<App {...props} store={store} />)
 
-    describe('should handle session timeout error response', async () => {
+    describe('should handle session timeout error response', () => {
       const appInstance = component.instance()
 
       beforeEach(() => {

--- a/src/dateHelpers.js
+++ b/src/dateHelpers.js
@@ -1,10 +1,20 @@
-import moment from 'moment'
+const moment = require('moment')
 
-export const DATE_TIME_FORMAT_SPEC = 'YYYY-MM-DDTHH:mm:ss'
-export const DATE_ONLY_FORMAT_SPEC = 'YYYY-MM-DD'
-export const DAY_MONTH_YEAR = 'DD/MM/YYYY'
-export const MOMENT_DAY_OF_THE_WEEK = 'dddd'
+const DATE_TIME_FORMAT_SPEC = 'YYYY-MM-DDTHH:mm:ss'
+const DATE_ONLY_FORMAT_SPEC = 'YYYY-MM-DD'
+const DAY_MONTH_YEAR = 'DD/MM/YYYY'
+const MOMENT_DAY_OF_THE_WEEK = 'dddd'
 
-export const DayOfTheWeek = dateTime => moment(dateTime, DATE_TIME_FORMAT_SPEC).format(MOMENT_DAY_OF_THE_WEEK)
-export const DayMonthYear = dateTime => moment(dateTime, DATE_TIME_FORMAT_SPEC).format(DAY_MONTH_YEAR)
-export const Time = dateTime => moment(dateTime, DATE_TIME_FORMAT_SPEC).format('HH:mm')
+const DayOfTheWeek = dateTime => moment(dateTime, DATE_TIME_FORMAT_SPEC).format(MOMENT_DAY_OF_THE_WEEK)
+const DayMonthYear = dateTime => moment(dateTime, DATE_TIME_FORMAT_SPEC).format(DAY_MONTH_YEAR)
+const Time = dateTime => moment(dateTime, DATE_TIME_FORMAT_SPEC).format('HH:mm')
+
+module.exports = {
+  DATE_TIME_FORMAT_SPEC,
+  DATE_ONLY_FORMAT_SPEC,
+  DAY_MONTH_YEAR,
+  MOMENT_DAY_OF_THE_WEEK,
+  DayOfTheWeek,
+  DayMonthYear,
+  Time,
+}


### PR DESCRIPTION
- Add nunjucks filters for getting date and time from string
- Removed `testMatch` from package.json as defaults suffice see https://jestjs.io/docs/en/configuration#testmatch-array-string
- Remove unnecessary async from describe in App.test.js
- Exported dateHelpers to use in node