### PR TITLE
Nn 2199 fix prisoners listed number bug

### DIFF
--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/mockapis/Elite2Api.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/mockapis/Elite2Api.groovy
@@ -295,21 +295,20 @@ class Elite2Api extends WireMockRule {
                                         .withStatus(200)))
     }
 
-    void stubGetActivityList(Caseload caseload, int locationId, String timeSlot, String date) {
+    void stubGetActivityList(Caseload caseload, int locationId, String timeSlot, String date, Boolean inThePast = false) {
 
-        stubProgEventsAtLocation(caseload, locationId, timeSlot, date,  ActivityResponse.activities)
+        def activityResponse = inThePast ? ActivityResponse.pastActivities : ActivityResponse.activities
+
+        stubProgEventsAtLocation(caseload, locationId, timeSlot, date,  activityResponse)
+
+        def offenderNumbers = extractOffenderNumbers(activityResponse)
+
         stubVisitsAtLocation(caseload, locationId, timeSlot, date)
         stubAppointmentsAtLocation(caseload, locationId, timeSlot, date)
 
-        def offenderNumbers = [
-                ActivityResponse.activity1_1.offenderNo,
-                ActivityResponse.activity2.offenderNo,
-                ActivityResponse.activity3.offenderNo
-        ]
-
         stubVisits(caseload, timeSlot, date, offenderNumbers, ActivityResponse.visits)
         stubAppointments(caseload, timeSlot, date, offenderNumbers, ActivityResponse.appointments)
-        stubActivities(caseload, timeSlot, date, offenderNumbers, ActivityResponse.activities)
+        stubActivities(caseload, timeSlot, date, offenderNumbers, activityResponse)
         stubCourtEvents(offenderNumbers, date, HouseblockResponse.courtEventsWithDifferentStatuesResponse)
         stubExternalTransfers(offenderNumbers, date)
         stubAlerts(offenderNumbers)

--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/mockapis/mockResponses/ActivityResponse.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/mockapis/mockResponses/ActivityResponse.groovy
@@ -105,6 +105,11 @@ class ActivityResponse {
             activity2,
             activity3
     ])
+    static  pastActivities = JsonOutput.toJson([
+            activity1_1,
+            activity1_2,
+            activity2,
+    ])
     static visits = JsonOutput.toJson([
             visit1
     ])

--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/pages/ActivityPage.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/pages/ActivityPage.groovy
@@ -26,6 +26,9 @@ class ActivityPage extends DatePickerPage {
         flags { bodyRows*.$('td', 5)*.$('span') }
         events { bodyRows*.$('td', 6)*.text() }
         eventsElsewhere { bodyRows*.$('td', 7).collect { it.$('ul li')*.text() } }
+        totalNumbers { $(name: 'total-number') }
+        prisonersListed { totalNumbers[0]}
+        sessionsAttended { totalNumbers[1]}
 
         attendRadioElements(required: false) { bodyRows*.$('td[data-qa="pay-option"]')*.$('input') }
         notAttendedRadioElements(required: false) { bodyRows*.$('td[data-qa="other-option"]')*.$('input') }

--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/specs/ActivitySpecification.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/specs/ActivitySpecification.groovy
@@ -74,6 +74,10 @@ class ActivitySpecification extends BrowserReportingSpec {
         flags[0]*.text() == ['ACCT','E-LIST','CAT A']
         flags[1]*.text() == ['CAT A Prov']
         flags[2]*.text() == ['CAT A High']
+
+        prisonersListed.text() == '3'
+        sessionsAttended.text() == '0'
+
         events == [
                 '17:00 - Activity 1',
                 '11:45 - Activity 1',
@@ -198,10 +202,21 @@ class ActivitySpecification extends BrowserReportingSpec {
         at ActivityPage
         activityTitle == 'loc1'
 
+        events == [
+                '17:00 - Activity 1',
+                '11:45 - Activity 1',
+                '17:45 - Activity 1',
+                '17:00 - Activity 2',
+                '17:00 - Activity 3'
+        ]
+
+        prisonersListed.text() == '3'
+        sessionsAttended.text() == '0'
+
         when: "I change selections and update"
         def firstOfMonthDisplayFormat = '01/08/2018'
         def firstOfMonthApiFormat = '2018-08-01'
-        elite2api.stubGetActivityList(ITAG_USER.workingCaseload, 1, 'PM', firstOfMonthApiFormat)
+        elite2api.stubGetActivityList(ITAG_USER.workingCaseload, 1, 'PM', firstOfMonthApiFormat, true)
         whereaboutsApi.stubGetAttendance(ITAG_USER.workingCaseload, 1, 'PM', firstOfMonthApiFormat)
         whereaboutsApi.stubGetAbsenceReasons()
         setDatePicker('2018', 'Aug', '1')
@@ -213,11 +228,12 @@ class ActivitySpecification extends BrowserReportingSpec {
 
         events == [
                 '17:00 - Activity 1',
-                '11:45 - Activity 1',
                 '17:45 - Activity 1',
                 '17:00 - Activity 2',
-                '17:00 - Activity 3'
         ]
+
+        prisonersListed.text() == '2'
+        sessionsAttended.text() == '0'
 
 
         when: "I go to the search page afresh"

--- a/src/Components/ResultsTable/elements/TotalResults/TotalResults.js
+++ b/src/Components/ResultsTable/elements/TotalResults/TotalResults.js
@@ -17,7 +17,7 @@ const TotalNumber = styled.span`
 
 const TotalResults = ({ label, totalResults }) => (
   <StyledTotalResults>
-    {label} <TotalNumber>{totalResults}</TotalNumber>
+    {label} <TotalNumber name="total-number">{totalResults}</TotalNumber>
   </StyledTotalResults>
 )
 

--- a/src/Components/ResultsTable/elements/TotalResults/__snapshots__/TotalResults.test.js.snap
+++ b/src/Components/ResultsTable/elements/TotalResults/__snapshots__/TotalResults.test.js.snap
@@ -4,7 +4,9 @@ exports[`<TotalResults /> should match the default snapshot 1`] = `
 <styled.div>
   Prisoners listed:
    
-  <styled.span>
+  <styled.span
+    name="total-number"
+  >
     0
   </styled.span>
 </styled.div>
@@ -14,7 +16,9 @@ exports[`<TotalResults /> should match with value snapshot 1`] = `
 <styled.div>
   Prisoners listed:
    
-  <styled.span>
+  <styled.span
+    name="total-number"
+  >
     10
   </styled.span>
 </styled.div>

--- a/src/ResultsActivity/ResultsActivity.js
+++ b/src/ResultsActivity/ResultsActivity.js
@@ -346,6 +346,7 @@ class ResultsActivity extends Component {
     }
 
     const unattendedOffenders = new Set()
+    const totalOffenders = new Set()
 
     const offenders =
       activityData &&
@@ -388,7 +389,7 @@ class ResultsActivity extends Component {
             eventDate: date,
           })
         }
-        this.totalOffenders.add(offenderNo)
+        totalOffenders.add(offenderNo)
 
         const { absentReason } = attendanceInfo || {}
         const otherActivitiesClasses = classNames({
@@ -461,6 +462,7 @@ class ResultsActivity extends Component {
       })
 
     this.unattendedOffenders = unattendedOffenders
+    this.totalOffenders = totalOffenders
 
     return (
       <div className="results-activity">


### PR DESCRIPTION
The totalOffenders variable was initiated once set on the
component at first render. There was no point at which that
variable was reset when the component updated, thus it sometimes
showed wrong results when the period was changed.

This adds an integration test to confirm correct behaviour.