### PR TITLE
NN-2206: Check activity has eventId before including it in batch actions

### DIFF
--- a/src/ResultsActivity/ResultsActivity.js
+++ b/src/ResultsActivity/ResultsActivity.js
@@ -224,20 +224,20 @@ class ResultsActivity extends Component {
     }
 
     const showUpdateAllControls = (activities, paidList) => {
-      let showControls = true
-      const attendanceInfo = activities.filter(activity => activity.attendanceInfo)
+      // Activities need an eventId in order to be updatable
+      // Ignore ones without when deciding whether to show the
+      // batch buttons - they can't be actioned.
+      const activitiesWithEventId = activities.filter(activity => activity.eventId)
+      const attendanceInfo = activitiesWithEventId.filter(activity => activity.attendanceInfo)
       const lockedCases = attendanceInfo.filter(activity => activity.attendanceInfo.locked === true)
 
-      if (
+      return !(
         !isWithinLastWeek(date) ||
         isAfterToday(date) ||
-        activityData.length === paidList ||
-        attendanceInfo.length === activities.length ||
-        lockedCases.length === activities.length
+        activitiesWithEventId.length === paidList ||
+        attendanceInfo.length === activitiesWithEventId.length ||
+        lockedCases.length === activitiesWithEventId.length
       )
-        showControls = false
-
-      return showControls
     }
 
     const { attendingAll, notRequiringAll } = this.state
@@ -381,7 +381,7 @@ class ResultsActivity extends Component {
           attendanceInfo,
         }
 
-        if (!attendanceInfo) {
+        if (!attendanceInfo && eventId) {
           unattendedOffenders.add({
             offenderNo,
             bookingId,

--- a/src/ResultsActivity/ResultsActivity.test.js
+++ b/src/ResultsActivity/ResultsActivity.test.js
@@ -495,7 +495,7 @@ describe('Offender activity list results component', () => {
 
   it('should not display pay all button if all prisoners are paid', () => {
     const component = shallow(
-      <ResultsActivity {...props} totalAttended={4} activityData={response} date={today} period="AM" />
+      <ResultsActivity {...props} totalAttended={3} activityData={response} date={today} period="AM" />
     )
 
     const attendAllLink = component
@@ -594,6 +594,7 @@ describe('Offender activity list results component', () => {
         cellLocation: `${PRISON}-A-1-1`,
         event: 'PA',
         eventDescription: 'Prison Activities',
+        eventId: 123,
         comment: 'Chapel',
         startTime: '2017-10-15T18:00:00',
         endTime: '2017-10-15T18:30:00',
@@ -607,6 +608,7 @@ describe('Offender activity list results component', () => {
         cellLocation: `${PRISON}-A-1-3`,
         event: 'PA',
         eventDescription: 'Prison Activities',
+        eventId: 456,
         comment: 'Chapel',
         startTime: '2017-10-15T18:00:00',
         endTime: '2017-10-15T18:30:00',
@@ -644,6 +646,7 @@ describe('Offender activity list results component', () => {
         cellLocation: `${PRISON}-A-1-1`,
         event: 'PA',
         eventDescription: 'Prison Activities',
+        eventId: 123,
         comment: 'Chapel',
         startTime: '2017-10-15T18:00:00',
         endTime: '2017-10-15T18:30:00',
@@ -657,6 +660,7 @@ describe('Offender activity list results component', () => {
         cellLocation: `${PRISON}-A-1-3`,
         event: 'PA',
         eventDescription: 'Prison Activities',
+        eventId: 456,
         comment: 'Chapel',
         startTime: '2017-10-15T18:00:00',
         endTime: '2017-10-15T18:30:00',
@@ -765,7 +769,7 @@ describe('Offender activity list results component', () => {
         const component = shallow(
           <ResultsActivity
             {...props}
-            totalAttended={2}
+            totalAttended={1}
             totalAbsent={2}
             activityData={response}
             date={today}
@@ -820,16 +824,6 @@ describe('Offender activity list results component', () => {
               eventId: 789,
               eventLocationId: undefined,
               offenderIndex: 2,
-              period: 'AM',
-              prisonId: 'SYI',
-              eventDate: '01/01/2017',
-            },
-            {
-              offenderNo: 'A1234AD',
-              bookingId: 4,
-              eventId: undefined,
-              eventLocationId: undefined,
-              offenderIndex: 3,
               period: 'AM',
               prisonId: 'SYI',
               eventDate: '01/01/2017',


### PR DESCRIPTION
Currently the batch actions will send all unattended activities on the pages, regardless if they have an eventId or not. We don't show the radio buttons when there's no eventId, but we didn't have a similar check for batch actions. This also updates the showing of the action buttons logic to only show them if there are updatable offenders remaining (checks for eventId again).