### PR TITLE
NN-2176 Remove no-param-reassign override and fix lint warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -26,7 +26,6 @@
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/jsx-props-no-spreading": 0, // disable as AirBnb says sparce usage is okay, and we mostly use in tests
     "no-underscore-dangle": ["error", { "allow": ["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"] }],
-    "no-param-reassign": [2, { "props": true }],
     "import/no-named-as-default": 0, // disable as we use connected components
     "jsx-a11y/label-has-associated-control": [2, { "assert": "either" }],
     "jsx-a11y/label-has-for": 0 // disable as has been deprecated and replaced by label-has-associated-control

--- a/backend/api/oauthEnabledClient.test.js
+++ b/backend/api/oauthEnabledClient.test.js
@@ -174,7 +174,7 @@ describe('Test clients built by oauthEnabledClient', () => {
         }
       })
       it('Should retry twice if request fails', async () => {
-        const pipe = new Promise((resolve, reject) => {
+        const pipe = new Promise(resolve => {
           mock
             .get('/api/users/me')
             .reply(500, { failure: 'one' })
@@ -199,7 +199,7 @@ describe('Test clients built by oauthEnabledClient', () => {
         expect(res.write).toHaveBeenCalled()
       })
       it('Should retry many time if configure with more retires if request fails', async () => {
-        const pipe = new Promise((resolve, reject) => {
+        const pipe = new Promise(resolve => {
           mock
             .get('/api/users/me')
             .reply(500, { failure: 'one' })
@@ -231,7 +231,7 @@ describe('Test clients built by oauthEnabledClient', () => {
         expect(res.write).toHaveBeenCalled()
       })
       it('Should set headers on response to pipe to', async () => {
-        const pipe = new Promise((resolve, reject) => {
+        const pipe = new Promise(resolve => {
           mock.get('/api/users/me').reply(200, Buffer.from('some binary data'), {
             'Content-Type': 'image/png',
             'Content-Length': 123,

--- a/backend/api/whereaboutsApi.js
+++ b/backend/api/whereaboutsApi.js
@@ -1,5 +1,3 @@
-const { arrayToQueryString } = require('../utils')
-
 const whereaboutsApiFactory = client => {
   const processResponse = () => response => response.body
 

--- a/backend/controllers/addAppointmentDetails.js
+++ b/backend/controllers/addAppointmentDetails.js
@@ -260,7 +260,6 @@ const addAppointmentDetailsFactory = (bulkAppointmentService, oauthApi, logError
           endOfPeriod: endOfPeriod && endOfPeriod.format('dddd D MMMM YYYY'),
         }
 
-        // eslint-disable-next-line no-param-reassign
         req.session.data = {
           appointmentType,
           appointmentTypeDescription: appointmentTypeDetails && appointmentTypeDetails.text,

--- a/backend/controllers/bulkAppointmentsConfirm.js
+++ b/backend/controllers/bulkAppointmentsConfirm.js
@@ -109,7 +109,6 @@ const bulkAppointmentsConfirmFactory = (elite2Api, logError) => {
     if (sameTimeAppointments === 'no') {
       const errors = validate(prisonersWithAppointmentTimes, date)
 
-      // eslint-disable-next-line no-param-reassign
       req.session.data.prisonersListed = prisonersWithAppointmentTimes
 
       if (errors.length > 0) {

--- a/backend/controllers/bulkAppointmentsUpload.js
+++ b/backend/controllers/bulkAppointmentsUpload.js
@@ -65,11 +65,9 @@ const bulkAppointmentsUploadFactory = (csvParserService, offenderLoader, logErro
           }
 
           if (prisonerList && prisonerList.length) {
-            // eslint-disable-next-line no-param-reassign
             req.session.data.prisonersListed = prisonerList
           }
           if (offenderNosNotFound && offenderNosNotFound.length) {
-            // eslint-disable-next-line no-param-reassign
             req.session.data.prisonersNotFound = offenderNosNotFound
           }
 

--- a/backend/controllers/setactivecaseload.js
+++ b/backend/controllers/setactivecaseload.js
@@ -6,7 +6,6 @@ const activeCaseloadFactory = elite2Api => {
 
     await elite2Api.setActiveCaseload(res.locals, { caseLoadId })
 
-    // eslint-disable-next-line no-param-reassign
     if (req.session && req.session.data) req.session.data.activeCaseLoadId = caseLoadId
     res.json({})
   })

--- a/backend/index.js
+++ b/backend/index.js
@@ -230,7 +230,6 @@ app.use(
 
 // Ensure cookie session is extended (once per minute) when user interacts with the server
 app.use((req, res, next) => {
-  // eslint-disable-next-line no-param-reassign
   req.session.nowInMinutes = Math.floor(Date.now() / 60e3)
   next()
 })
@@ -265,7 +264,6 @@ app.use(express.static(path.join(__dirname, '../build')))
 app.use(async (req, res, next) => {
   const { userDetails } = req.session
   if (!userDetails) {
-    // eslint-disable-next-line no-param-reassign
     req.session.userDetails = await oauthApi.currentUser(res.locals)
   }
   next()

--- a/backend/sessionManagementRoutes.js
+++ b/backend/sessionManagementRoutes.js
@@ -21,14 +21,12 @@ const configureRoutes = ({ app, tokenRefresher, mailTo, homeLink }) => {
   }`
 
   const remoteLoginIndex = (req, res, next) => {
-    // eslint-disable-next-line no-param-reassign
     req.session.returnTo = req.query.returnTo
     return passport.authenticate('oauth2')(req, res, next)
   }
 
   const logout = (req, res) => {
     req.logout()
-    // eslint-disable-next-line no-param-reassign
     req.session = null
     res.redirect(authLogoutUrl)
   }

--- a/backend/tests/activeCaseLoad.test.js
+++ b/backend/tests/activeCaseLoad.test.js
@@ -2,7 +2,6 @@ const { activeCaseloadFactory } = require('../controllers/setactivecaseload')
 
 describe('Switch caseload', () => {
   const elite2Api = {}
-  const context = {}
   const req = {
     session: {
       data: {

--- a/backend/tests/adjudicationHistoryService.test.js
+++ b/backend/tests/adjudicationHistoryService.test.js
@@ -250,7 +250,6 @@ describe('Adjudication History Service', () => {
     expect(elite2Api.getAdjudicationDetails.mock.calls[0]).toEqual([{}, 'OFF-1', 'ADJ-1'])
   })
 
-  /* eslint no-param-reassign: "error" */
   it('pagination is only applied to adjudication retrieval requests', async () => {
     elite2Api.getAdjudications.mockImplementation(ctx => {
       ctx.adjudicationResponseHeaders = true


### PR DESCRIPTION
- Removed `no-param-reassign` override from our own eslint file now that eslint-config-airbnb has `req` as an exception. See https://github.com/airbnb/javascript/blob/ab72ab9e90f403e90590f8815e0563248af10470/packages/eslint-config-airbnb-base/rules/best-practices.js#L187
- Also removed a few unused vars which were triggering warnings