### PR TITLE
NN-2030: Make sure correct event is shown for absence, update page heading

### DIFF
--- a/backend/controllers/attendanceStatistics.js
+++ b/backend/controllers/attendanceStatistics.js
@@ -153,7 +153,9 @@ const attendanceStatisticsFactory = (oauthApi, elite2Api, whereaboutsApi, logErr
       const absences = attendances.filter(absence => absence.absentReason === reason)
 
       const offenderData = absences.map(absence => {
-        const offenderActivity = activities.find(activity => activity.bookingId === absence.bookingId)
+        const offenderActivity = activities.find(
+          activity => activity.bookingId === absence.bookingId && activity.eventId === absence.eventId
+        )
         return {
           offenderName: `${capitalize(offenderActivity.lastName)}, ${capitalize(offenderActivity.firstName)}`,
           offenderNo: offenderActivity.offenderNo,
@@ -190,6 +192,7 @@ const attendanceStatisticsFactory = (oauthApi, elite2Api, whereaboutsApi, logErr
 
       const displayReason = pascalToString(reason)
       const displayDate = readableDateFormat(date, 'DD/MM/YYYY')
+      const displayPeriod = readablePeriod(period)
 
       const sortOptions = [
         { value: '0_ascending', text: 'Name (A-Z)' },
@@ -201,7 +204,9 @@ const attendanceStatisticsFactory = (oauthApi, elite2Api, whereaboutsApi, logErr
       ]
 
       res.render('attendanceStatisticsOffendersList.njk', {
-        title: `${displayReason} - ${displayDate}`,
+        title: `${displayReason}`,
+        displayDate,
+        displayPeriod,
         reason: displayReason,
         dashboardUrl: `/manage-prisoner-whereabouts/attendance-reason-statistics?agencyId=${agencyId}&period=${period}&date=${date}`,
         offenders,

--- a/backend/tests/attendanceStatistics.test.js
+++ b/backend/tests/attendanceStatistics.test.js
@@ -309,8 +309,10 @@ describe('Attendance reason statistics', () => {
         dashboardUrl:
           '/manage-prisoner-whereabouts/attendance-reason-statistics?agencyId=LEI&period=AM&date=10/10/2019',
         caseLoadId: 'LEI',
-        title: 'Acceptable absence - 10 October 2019',
+        title: 'Acceptable absence',
         reason: 'Acceptable absence',
+        displayDate: '10 October 2019',
+        displayPeriod: 'Morning',
         offenders: [
           [
             {

--- a/views/attendanceStatisticsOffendersList.njk
+++ b/views/attendanceStatisticsOffendersList.njk
@@ -26,6 +26,7 @@
 {% endblock %}
 {% block content %}
 
+<span class="govuk-caption-xl">{{displayDate}} - {{displayPeriod}}</span>
 <h1 class="govuk-heading-xl">{{title}}</h1>
 
 {{ govukSelect({


### PR DESCRIPTION
Previous we were returning the first event, which wasn't necessarily the one the absence was for. This resolves and updates the page heading.