### PR TITLE
DT-343 fixed issue when offender has no sentence related documents

### DIFF
--- a/backend/controllers/probationDocuments.js
+++ b/backend/controllers/probationDocuments.js
@@ -95,7 +95,8 @@ const probationDocumentsFactory = (oauthApi, elite2Api, communityApi, systemOaut
         ])
 
         const convictionsWithDocuments = convictions.map(conviction => {
-          const relatedConviction = allDocuments.convictions.find(
+          const convictionDocuments = allDocuments.convictions || []
+          const relatedConviction = convictionDocuments.find(
             // community api mixes types for convictionId so use string
             documentConviction => documentConviction.convictionId.toString() === conviction.convictionId.toString()
           )

--- a/backend/tests/probationDocuments.test.js
+++ b/backend/tests/probationDocuments.test.js
@@ -323,6 +323,27 @@ describe('Probation documents', () => {
         )
       })
 
+      it('should allow page to be displayed when no documents but with convictions', async () => {
+        communityApi.getOffenderConvictions.mockReturnValue([aConviction({ convictionId: 1 })])
+        communityApi.getOffenderDocuments.mockReturnValue({})
+
+        await page(req, res)
+
+        expect(res.render).toHaveBeenCalledWith(
+          'probationDocuments.njk',
+          expect.objectContaining({
+            documents: {
+              offenderDocuments: [],
+              convictions: expect.objectContaining([
+                expect.objectContaining({
+                  documents: [],
+                }),
+              ]),
+            },
+          })
+        )
+      })
+
       it('should supply page with conviction related document', async () => {
         communityApi.getOffenderConvictions.mockReturnValue([
           aConviction({ convictionId: 1 }),


### PR DESCRIPTION
Fix a scenario (unlikely to happen in live) where no documents have ever been uploaded for any conviction ever