### PR TITLE
NN-1902: Add error handling if the locationId is missing

### DIFF
--- a/backend/controllers/activityList.js
+++ b/backend/controllers/activityList.js
@@ -58,6 +58,11 @@ const getActivityListFactory = (elite2Api, whereaboutsApi, config) => {
 
   const getActivityList = async (context, agencyId, locationIdString, frontEndDate, timeSlot) => {
     const locationId = Number.parseInt(locationIdString, 10)
+
+    if (!locationId) {
+      throw new Error('Location ID is missing')
+    }
+
     const date = switchDateFormat(frontEndDate)
 
     const absenceReasons =

--- a/backend/tests/activityList.test.js
+++ b/backend/tests/activityList.test.js
@@ -481,6 +481,18 @@ describe('Activity list controller', () => {
       )
     })
 
+    it('should throw error when location is not a number and no call the APIs', async done => {
+      try {
+        await activityList({}, 'LEI', '--', '23/11/2018', 'PM')
+      } catch (e) {
+        expect(e).toEqual(new Error('Location ID is missing'))
+        expect(whereaboutsApi.getAttendance.mock.calls.length).toBe(0)
+        expect(elite2Api.getActivityList.mock.calls.length).toBe(0)
+
+        done()
+      }
+    })
+
     it('should load attendance details', async () => {
       whereaboutsApi.getAttendance.mockReturnValue({
         attendances: [


### PR DESCRIPTION
Someway somehow (probably JS async issue) sometimes users manage to make a request where the locationId is '--'. Currently this is being passed onto the APIs, this is to catch that error and stop the process before it gets to elite2.