### PR TITLE
NN-2252/NN-2253 Add value parameter to raiseAnalyticsEvent

### DIFF
--- a/backend/controllers/bulkAppointmentsClashes.js
+++ b/backend/controllers/bulkAppointmentsClashes.js
@@ -143,8 +143,9 @@ const bulkAppointmentsClashesFactory = (elite2Api, logError) => {
 
     raiseAnalyticsEvent(
       'Bulk Appointments',
-      `${remainingPrisoners.length * (count || 1)} appointments created at ${activeCaseLoadId}`,
-      `Appointment type - ${appointmentTypeDescription}`
+      `Appointments created at ${activeCaseLoadId}`,
+      `Appointment type - ${appointmentTypeDescription}`,
+      remainingPrisoners.length * (count || 1)
     )
 
     return res.redirect('/bulk-appointments/appointments-added')

--- a/backend/controllers/bulkAppointmentsConfirm.js
+++ b/backend/controllers/bulkAppointmentsConfirm.js
@@ -175,8 +175,9 @@ const bulkAppointmentsConfirmFactory = (elite2Api, logError) => {
 
       raiseAnalyticsEvent(
         'Bulk Appointments',
-        `${prisonersWithAppointmentTimes.length * (count || 1)} appointments created at ${activeCaseLoadId}`,
-        `Appointment type - ${appointmentTypeDescription}`
+        `Appointments created at ${activeCaseLoadId}`,
+        `Appointment type - ${appointmentTypeDescription}`,
+        prisonersWithAppointmentTimes.length * (count || 1)
       )
 
       return res.redirect('/bulk-appointments/appointments-added')

--- a/backend/raiseAnalyticsEvent.js
+++ b/backend/raiseAnalyticsEvent.js
@@ -1,13 +1,14 @@
 const ua = require('universal-analytics')
 const config = require('./config')
 
-const raiseAnalyticsEvent = (category, action, label) => {
+const raiseAnalyticsEvent = (category, action, label, value) => {
   if (!config.analytics.googleAnalyticsId) return Promise.resolve()
   const ga = ua(config.analytics.googleAnalyticsId)
   const data = {
     ec: category,
     ea: action,
     el: label,
+    ev: value,
   }
   return ga.event(data).send()
 }

--- a/backend/tests/bulkAppointmentsClashes.test.js
+++ b/backend/tests/bulkAppointmentsClashes.test.js
@@ -306,8 +306,9 @@ describe('appointment clashes', () => {
 
           expect(raiseAnalyticsEvent).toBeCalledWith(
             'Bulk Appointments',
-            `2 appointments created at ${req.session.userDetails.activeCaseLoadId}`,
-            `Appointment type - ${appointmentDetails.appointmentTypeDescription}`
+            `Appointments created at ${req.session.userDetails.activeCaseLoadId}`,
+            `Appointment type - ${appointmentDetails.appointmentTypeDescription}`,
+            2
           )
         })
       })
@@ -360,8 +361,9 @@ describe('appointment clashes', () => {
 
           expect(raiseAnalyticsEvent).toBeCalledWith(
             'Bulk Appointments',
-            `20 appointments created at ${req.session.userDetails.activeCaseLoadId}`,
-            `Appointment type - ${appointmentDetails.appointmentTypeDescription}`
+            `Appointments created at ${req.session.userDetails.activeCaseLoadId}`,
+            `Appointment type - ${appointmentDetails.appointmentTypeDescription}`,
+            20
           )
         })
       })

--- a/backend/tests/bulkAppointmentsConfirm.test.js
+++ b/backend/tests/bulkAppointmentsConfirm.test.js
@@ -148,8 +148,9 @@ describe('when confirming bulk appointment details', () => {
           expect(res.redirect).toBeCalledWith('/bulk-appointments/appointments-added')
           expect(raiseAnalyticsEvent).toBeCalledWith(
             'Bulk Appointments',
-            `4 appointments created at ${req.session.userDetails.activeCaseLoadId}`,
-            `Appointment type - ${appointmentDetails.appointmentTypeDescription}`
+            `Appointments created at ${req.session.userDetails.activeCaseLoadId}`,
+            `Appointment type - ${appointmentDetails.appointmentTypeDescription}`,
+            4
           )
         })
       })
@@ -333,8 +334,9 @@ describe('when confirming bulk appointment details', () => {
 
         expect(raiseAnalyticsEvent).toBeCalledWith(
           'Bulk Appointments',
-          `20 appointments created at ${req.session.userDetails.activeCaseLoadId}`,
-          `Appointment type - ${appointmentDetails.appointmentTypeDescription}`
+          `Appointments created at ${req.session.userDetails.activeCaseLoadId}`,
+          `Appointment type - ${appointmentDetails.appointmentTypeDescription}`,
+          20
         )
       })
     })


### PR DESCRIPTION
Add value parameter so we can remove the number of people paid/appointments created from the Event action name and make the figures easier to collate.

![image](https://user-images.githubusercontent.com/1067537/68595538-87014d80-0491-11ea-80b2-7a9947b4e72e.png)
