### PR TITLE
NN-2288 Remove rogue console log which triggered error in IE11

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -61,7 +61,6 @@ $(document).ready(function() {
         },
       })
         .done(function(data) {
-          console.log({ data })
           container.html(data).show()
         })
         .fail(function() {


### PR DESCRIPTION
Remove `console.log` in main.js which was causing none of the JS in that file to run in IE11 because of es2015 syntax.

<img width="342" alt="Screenshot 2020-01-06 at 14 06 36" src="https://user-images.githubusercontent.com/1067537/71822881-ecd31580-308d-11ea-844d-5a7d5b9284dd.png">
