### PR TITLE
NN-2401 Prevent some external movements being shown on future lists

### DIFF
--- a/backend/utils.js
+++ b/backend/utils.js
@@ -185,6 +185,12 @@ const isOffenderNumber = string => {
   return offenderIdPattern.test(string)
 }
 
+const isAfterToday = date => {
+  const dayAfter = moment().add(1, 'day')
+  const daysDifference = moment(date).diff(dayAfter, 'day')
+  return daysDifference >= 0
+}
+
 module.exports = {
   isToday,
   isTodayOrAfter,
@@ -213,4 +219,5 @@ module.exports = {
   chunkArray,
   capitalizeStart,
   isOffenderNumber,
+  isAfterToday,
 }


### PR DESCRIPTION
Do not show the following on lists when the selected date is in the future.

- Scheduled transfers
- Court events
- Release information