### PR TITLE
DT-526 schedule groups retrieved from whereabouts

### DIFF
--- a/backend/api/elite2Api.js
+++ b/backend/api/elite2Api.js
@@ -23,8 +23,8 @@ const elite2ApiFactory = client => {
   // However, only 'caseLoadId' has meaning.  The other two properties can take *any* non-blank value and these will be ignored.
   const setActiveCaseload = (context, caseload) => put(context, '/api/users/me/activeCaseLoad', caseload)
 
-  const getHouseblockList = (context, agencyId, groupName, date, timeSlot) =>
-    get(context, `/api/schedules/${agencyId}/groups/${groupName}?date=${date}&timeSlot=${timeSlot}`)
+  const getHouseblockList = (context, agencyId, locationIds, date, timeSlot) =>
+    post(context, `/api/schedules/${agencyId}/events-by-location-ids?date=${date}&timeSlot=${timeSlot}`, locationIds)
 
   const getActivityList = (context, { agencyId, locationId, usage, date, timeSlot }) =>
     get(

--- a/backend/api/whereaboutsApi.js
+++ b/backend/api/whereaboutsApi.js
@@ -40,6 +40,9 @@ const whereaboutsApiFactory = client => {
 
   const searchGroups = (context, agencyId) => get(context, `/agencies/${agencyId}/locations/groups`)
 
+  const getAgencyGroupLocations = (context, agencyId, groupName) =>
+    get(context, `/locations/groups/${agencyId}/${groupName}`)
+
   return {
     getAttendance,
     getAttendanceForBookings,
@@ -51,6 +54,7 @@ const whereaboutsApiFactory = client => {
     getAttendanceStats,
     getAbsences,
     searchGroups,
+    getAgencyGroupLocations,
   }
 }
 

--- a/backend/controllers/attendance/houseblockList.js
+++ b/backend/controllers/attendance/houseblockList.js
@@ -64,9 +64,10 @@ const getHouseblockListFactory = (elite2Api, whereaboutsApi, config) => {
   } = config
   const updateAttendanceEnabled = agencyId => !production || updateAttendancePrisons.includes(agencyId)
   const getHouseblockList = async (context, agencyId, groupName, date, timeSlot, wingStatus) => {
+    const locationIds = await whereaboutsApi.getAgencyGroupLocations(context, agencyId, groupName)
     const formattedDate = switchDateFormat(date)
     // Returns array ordered by inmate/cell or name, then start time
-    const data = await elite2Api.getHouseblockList(context, agencyId, groupName, formattedDate, timeSlot)
+    const data = await elite2Api.getHouseblockList(context, agencyId, locationIds, formattedDate, timeSlot)
 
     const offenderNumbers = distinct(data.map(offender => offender.offenderNo))
 

--- a/backend/controllers/attendance/houseblockList.js
+++ b/backend/controllers/attendance/houseblockList.js
@@ -64,7 +64,8 @@ const getHouseblockListFactory = (elite2Api, whereaboutsApi, config) => {
   } = config
   const updateAttendanceEnabled = agencyId => !production || updateAttendancePrisons.includes(agencyId)
   const getHouseblockList = async (context, agencyId, groupName, date, timeSlot, wingStatus) => {
-    const locationIds = await whereaboutsApi.getAgencyGroupLocations(context, agencyId, groupName)
+    const locations = await whereaboutsApi.getAgencyGroupLocations(context, agencyId, groupName)
+    const locationIds = locations.map(location => location.locationId)
     const formattedDate = switchDateFormat(date)
     // Returns array ordered by inmate/cell or name, then start time
     const data = await elite2Api.getHouseblockList(context, agencyId, locationIds, formattedDate, timeSlot)

--- a/backend/tests/houseblockList.test.js
+++ b/backend/tests/houseblockList.test.js
@@ -196,13 +196,16 @@ describe('Houseblock list controller', () => {
     whereaboutsApi.getAbsenceReasons.mockReturnValue({
       triggersIEPWarning: ['UnacceptableAbsence', 'Refused'],
     })
+    whereaboutsApi.getAgencyGroupLocations = jest.fn()
   })
 
   it('Should add visit and appointment details to array', async () => {
+    whereaboutsApi.getAgencyGroupLocations.mockReturnValue([1, 2])
     elite2Api.getHouseblockList.mockImplementationOnce(() => createResponse())
 
     const response = await houseblockList({})
 
+    expect(whereaboutsApi.getAgencyGroupLocations.mock.calls.length).toBe(1)
     expect(elite2Api.getHouseblockList.mock.calls.length).toBe(1)
 
     expect(response.length).toBe(4)

--- a/backend/tests/houseblockList.test.js
+++ b/backend/tests/houseblockList.test.js
@@ -197,10 +197,10 @@ describe('Houseblock list controller', () => {
       triggersIEPWarning: ['UnacceptableAbsence', 'Refused'],
     })
     whereaboutsApi.getAgencyGroupLocations = jest.fn()
+    whereaboutsApi.getAgencyGroupLocations.mockReturnValue([])
   })
 
   it('Should add visit and appointment details to array', async () => {
-    whereaboutsApi.getAgencyGroupLocations.mockReturnValue([1, 2])
     elite2Api.getHouseblockList.mockImplementationOnce(() => createResponse())
 
     const response = await houseblockList({})
@@ -252,6 +252,17 @@ describe('Houseblock list controller', () => {
     expect(response[0].activities[3].comment).toBe('comment14')
     expect(response[0].activities[3].startTime).toBe('2017-10-15T17:00:00')
     expect(response[0].activities[3].endTime).toBe('2017-10-15T17:30:00')
+  })
+
+  it('Should pass location Ids to getHouseblockList', async () => {
+    whereaboutsApi.getAgencyGroupLocations.mockReturnValue([{ locationId: 1 }, { locationId: 2 }])
+    elite2Api.getHouseblockList.mockImplementationOnce(() => createResponse())
+
+    await houseblockList({})
+
+    expect(whereaboutsApi.getAgencyGroupLocations.mock.calls.length).toBe(1)
+    expect(elite2Api.getHouseblockList.mock.calls.length).toBe(1)
+    expect(elite2Api.getHouseblockList.mock.calls[0][2]).toStrictEqual([1, 2])
   })
 
   it('Should correctly choose main activity', async () => {

--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/mockapis/Elite2Api.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/mockapis/Elite2Api.groovy
@@ -93,9 +93,9 @@ class Elite2Api extends WireMockRule {
         )
     }
 
-    void stubGetHouseblockList(Caseload caseload, String groupName, String timeSlot, String date) {
+    void stubGetHouseblockList(Caseload caseload, String timeSlot, String date) {
         this.stubFor(
-                get("/api/schedules/${caseload.id}/groups/${groupName}?date=${date}&timeSlot=${timeSlot}")
+                post("/api/schedules/${caseload.id}/events-by-location-ids?date=${date}&timeSlot=${timeSlot}")
                         .willReturn(
                                 aResponse()
                                         .withBody(HouseblockResponse.responseCellOrder)
@@ -103,7 +103,7 @@ class Elite2Api extends WireMockRule {
                                         .withStatus(200))
         )
         this.stubFor(
-                get("/api/schedules/${caseload.id}/groups/${groupName}?date=${date}&timeSlot=${timeSlot}")
+                post("/api/schedules/${caseload.id}/events-by-location-ids?date=${date}&timeSlot=${timeSlot}")
                         .withHeader('Sort-Fields', equalTo('lastName'))
                         .willReturn(
                                 aResponse()
@@ -121,9 +121,9 @@ class Elite2Api extends WireMockRule {
         stubAssessments(offenderNumbers)
     }
 
-    void stubGetHouseblockListWithMultipleActivities(Caseload caseload, String groupName, String timeSlot, String date) {
+    void stubGetHouseblockListWithMultipleActivities(Caseload caseload, String timeSlot, String date) {
         this.stubFor(
-                get("/api/schedules/${caseload.id}/groups/${groupName}?date=${date}&timeSlot=${timeSlot}")
+                post("/api/schedules/${caseload.id}/events-by-location-ids?date=${date}&timeSlot=${timeSlot}")
                         .willReturn(
                                 aResponse()
                                         .withBody(HouseblockResponse.responseMultipleActivities)
@@ -139,9 +139,9 @@ class Elite2Api extends WireMockRule {
         stubAssessments(offenderNumbers)
     }
 
-    void stubGetHouseblockListWithNoActivityOffender(Caseload caseload, String groupName, String timeSlot, String date) {
+    void stubGetHouseblockListWithNoActivityOffender(Caseload caseload, String timeSlot, String date) {
         this.stubFor(
-                get("/api/schedules/${caseload.id}/groups/${groupName}?date=${date}&timeSlot=${timeSlot}")
+                post("/api/schedules/${caseload.id}/events-by-location-ids?date=${date}&timeSlot=${timeSlot}")
                         .willReturn(
                                 aResponse()
                                         .withBody(HouseblockResponse.responseNoActivities)
@@ -157,9 +157,9 @@ class Elite2Api extends WireMockRule {
         stubAssessments(offenderNumbers)
     }
 
-    void stubGetHouseblockListWithAllCourtEvents(Caseload caseload, String groupName, String timeSlot, String date) {
+    void stubGetHouseblockListWithAllCourtEvents(Caseload caseload, String timeSlot, String date) {
         this.stubFor(
-                get("/api/schedules/${caseload.id}/groups/${groupName}?date=${date}&timeSlot=${timeSlot}")
+                post("/api/schedules/${caseload.id}/events-by-location-ids?date=${date}&timeSlot=${timeSlot}")
                         .willReturn(
                                 aResponse()
                                         .withBody(HouseblockResponse.responseNoActivities)

--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/mockapis/WhereaboutsApi.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/mockapis/WhereaboutsApi.groovy
@@ -195,6 +195,17 @@ public class WhereaboutsApi extends WireMockRule {
         )
     }
 
+    void stubGetAgencyGroupLocations(agencyId, groupName) {
+        this.stubFor(
+                get("/locations/groups/${agencyId}/${groupName}")
+                        .willReturn(aResponse()
+                                .withStatus(200)
+                                .withHeader('Content-Type', 'application/json')
+                        )
+        )
+
+    }
+
     void verifyPostAttendance() {
         this.verify(postRequestedFor(urlEqualTo('/attendance')))
     }

--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/mockapis/WhereaboutsApi.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/mockapis/WhereaboutsApi.groovy
@@ -201,6 +201,7 @@ public class WhereaboutsApi extends WireMockRule {
                         .willReturn(aResponse()
                                 .withStatus(200)
                                 .withHeader('Content-Type', 'application/json')
+                                .withBody("[]")
                         )
         )
 

--- a/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/specs/HouseblockSpecification.groovy
+++ b/prisonstaffhub-specs/src/test/groovy/uk/gov/justice/digital/hmpps/prisonstaffhub/specs/HouseblockSpecification.groovy
@@ -40,7 +40,8 @@ class HouseblockSpecification extends BrowserReportingSpec {
         when: "I select and display a location"
         String today = getNow()
 
-        elite2api.stubGetHouseblockList(ITAG_USER.workingCaseload, '1', 'AM', today)
+        whereaboutsApi.stubGetAgencyGroupLocations(ITAG_USER.workingCaseload, '1')
+        elite2api.stubGetHouseblockList(ITAG_USER.workingCaseload, 'AM', today)
         whereaboutsApi.stubGetAbsenceReasons()
         whereaboutsApi.stubGetAttendanceForBookings(ITAG_USER.workingCaseload, 'AM', today)
 
@@ -110,7 +111,8 @@ class HouseblockSpecification extends BrowserReportingSpec {
         fixture.toSearch()
         this.initialPeriod = period.value()
         def today = getNow()
-        elite2api.stubGetHouseblockList(ITAG_USER.workingCaseload, '1', 'PM', today)
+        whereaboutsApi.stubGetAgencyGroupLocations(ITAG_USER.workingCaseload, '1')
+        elite2api.stubGetHouseblockList(ITAG_USER.workingCaseload, 'PM', today)
         whereaboutsApi.stubGetAbsenceReasons()
         whereaboutsApi.stubGetAttendanceForBookings(ITAG_USER.workingCaseload, 'PM', today)
 
@@ -138,7 +140,8 @@ class HouseblockSpecification extends BrowserReportingSpec {
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
         def today = simpleDateFormat.format(new Date());
 
-        elite2api.stubGetHouseblockListWithMultipleActivities(ITAG_USER.workingCaseload, '1', 'AM', today)
+        whereaboutsApi.stubGetAgencyGroupLocations(ITAG_USER.workingCaseload, '1')
+        elite2api.stubGetHouseblockListWithMultipleActivities(ITAG_USER.workingCaseload, 'AM', today)
         whereaboutsApi.stubGetAbsenceReasons()
         whereaboutsApi.stubGetAttendanceForBookings(ITAG_USER.workingCaseload, 'AM', today)
 
@@ -165,7 +168,8 @@ class HouseblockSpecification extends BrowserReportingSpec {
 
         when: "I select and display a location"
         def today = getNow()
-        elite2api.stubGetHouseblockListWithNoActivityOffender(ITAG_USER.workingCaseload, '1', 'AM', today)
+        whereaboutsApi.stubGetAgencyGroupLocations(ITAG_USER.workingCaseload, '1')
+        elite2api.stubGetHouseblockListWithNoActivityOffender(ITAG_USER.workingCaseload, 'AM', today)
         whereaboutsApi.stubGetAbsenceReasons()
         whereaboutsApi.stubGetAttendanceForBookings(ITAG_USER.workingCaseload, 'AM', today)
 
@@ -189,7 +193,8 @@ class HouseblockSpecification extends BrowserReportingSpec {
         when: "I select and display a location"
         def today = getNow()
 
-        elite2api.stubGetHouseblockListWithNoActivityOffender(ITAG_USER.workingCaseload, '1', 'AM', today)
+        whereaboutsApi.stubGetAgencyGroupLocations(ITAG_USER.workingCaseload, '1')
+        elite2api.stubGetHouseblockListWithNoActivityOffender(ITAG_USER.workingCaseload, 'AM', today)
         whereaboutsApi.stubGetAbsenceReasons()
         whereaboutsApi.stubGetAttendanceForBookings(ITAG_USER.workingCaseload, 'AM', today)
         location = '1'
@@ -212,7 +217,8 @@ class HouseblockSpecification extends BrowserReportingSpec {
         when: 'I select and display a location'
         def today = getNow()
 
-        elite2api.stubGetHouseblockListWithNoActivityOffender(ITAG_USER.workingCaseload, '1', 'AM', today)
+        whereaboutsApi.stubGetAgencyGroupLocations(ITAG_USER.workingCaseload, '1')
+        elite2api.stubGetHouseblockListWithNoActivityOffender(ITAG_USER.workingCaseload, 'AM', today)
         whereaboutsApi.stubGetAbsenceReasons()
         whereaboutsApi.stubGetAttendanceForBookings(ITAG_USER.workingCaseload, 'AM', today)
         location = '1'
@@ -234,7 +240,8 @@ class HouseblockSpecification extends BrowserReportingSpec {
         when: 'I select and display a location'
         def today = getNow()
 
-        elite2api.stubGetHouseblockListWithAllCourtEvents(ITAG_USER.workingCaseload, '1', 'AM', today)
+        whereaboutsApi.stubGetAgencyGroupLocations(ITAG_USER.workingCaseload, '1')
+        elite2api.stubGetHouseblockListWithAllCourtEvents(ITAG_USER.workingCaseload, 'AM', today)
         whereaboutsApi.stubGetAbsenceReasons()
         whereaboutsApi.stubGetAttendanceForBookings(ITAG_USER.workingCaseload, 'AM', today)
         location = '1'
@@ -257,7 +264,8 @@ class HouseblockSpecification extends BrowserReportingSpec {
 
         when: 'I select and display a location'
         def today = getNow()
-        elite2api.stubGetHouseblockListWithAllCourtEvents(ITAG_USER.workingCaseload, '1', 'AM', today)
+        whereaboutsApi.stubGetAgencyGroupLocations(ITAG_USER.workingCaseload, '1')
+        elite2api.stubGetHouseblockListWithAllCourtEvents(ITAG_USER.workingCaseload, 'AM', today)
         whereaboutsApi.stubGetAbsenceReasons()
         whereaboutsApi.stubGetAttendanceForBookings(ITAG_USER.workingCaseload, 'AM', today)
         location = '1'
@@ -285,7 +293,8 @@ class HouseblockSpecification extends BrowserReportingSpec {
         when: 'I select and display a location'
         def today = getNow()
 
-        elite2api.stubGetHouseblockListWithAllCourtEvents(ITAG_USER.workingCaseload, '1', 'AM', today)
+        whereaboutsApi.stubGetAgencyGroupLocations(ITAG_USER.workingCaseload, '1')
+        elite2api.stubGetHouseblockListWithAllCourtEvents(ITAG_USER.workingCaseload, 'AM', today)
         whereaboutsApi.stubGetAbsenceReasons()
         whereaboutsApi.stubGetAttendanceForBookings(ITAG_USER.workingCaseload, 'AM', today, [])
         whereaboutsApi.stubPostAttendance()
@@ -310,7 +319,8 @@ class HouseblockSpecification extends BrowserReportingSpec {
         when: 'I select and display a location'
         def today = getNow()
 
-        elite2api.stubGetHouseblockListWithAllCourtEvents(ITAG_USER.workingCaseload, '1', 'AM', today)
+        whereaboutsApi.stubGetAgencyGroupLocations(ITAG_USER.workingCaseload, '1')
+        elite2api.stubGetHouseblockListWithAllCourtEvents(ITAG_USER.workingCaseload, 'AM', today)
         whereaboutsApi.stubGetAbsenceReasons()
         whereaboutsApi.stubGetAttendanceForBookings(ITAG_USER.workingCaseload, 'AM', today, [])
         whereaboutsApi.stubPostAttendance()


### PR DESCRIPTION
As part of the move of location group property files from elite2 to whereabouts, any requests to retrieve location groups must be made to whereabouts.  
This means that we have changed the elite2 endpoint used by getHouseblockList to receive a list of location ids as input instead of deriving the locations by itself - it can't derive locations as it doesn't know about the location group property files anymore.