### PR TITLE
NN-2647 use res locals to store user data

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -28,6 +28,8 @@ app.set('trust proxy', 1) // trust first proxy
 app.set('view engine', 'ejs')
 app.set('view engine', 'njk')
 
+nunjucksSetup(app, path)
+
 app.use(setupBodyParsers())
 app.use(setupHealthChecks())
 app.use(setupWebSecurity())
@@ -35,11 +37,8 @@ app.use(setupWebSession())
 app.use(setupAuth({ oauthApi: apis.oauthApi }))
 app.use(setupSass())
 app.use(setupWebpackForDev())
-
 app.use(setupRedirects())
-
-const njkEnv = nunjucksSetup(app, path)
-app.use(routes({ ...apis, njkEnv }))
+app.use(routes({ ...apis }))
 
 app.use(setupStaticContent())
 

--- a/backend/middleware/currentUser.js
+++ b/backend/middleware/currentUser.js
@@ -11,8 +11,9 @@ module.exports = ({ elite2Api, oauthApi }) => async (req, res, next) => {
     const caseloads = req.session.allCaseloads
     const { name, activeCaseLoadId } = req.session.userDetails
 
-    res.locals.headerData = {
-      caseloads,
+    res.locals.user = {
+      ...res.locals.user,
+      allCaseloads: caseloads,
       displayName: name,
       activeCaseLoad: caseloads.find(cl => cl.caseLoadId === activeCaseLoadId),
     }

--- a/backend/middleware/currentUser.js
+++ b/backend/middleware/currentUser.js
@@ -1,4 +1,4 @@
-module.exports = ({ elite2Api, oauthApi, njkEnv }) => async (req, res, next) => {
+module.exports = ({ elite2Api, oauthApi }) => async (req, res, next) => {
   if (!req.xhr) {
     if (!req.session.userDetails) {
       const userDetails = await oauthApi.currentUser(res.locals)
@@ -11,11 +11,11 @@ module.exports = ({ elite2Api, oauthApi, njkEnv }) => async (req, res, next) => 
     const caseloads = req.session.allCaseloads
     const { name, activeCaseLoadId } = req.session.userDetails
 
-    njkEnv.addGlobal('allCaseloads', caseloads)
-    njkEnv.addGlobal('user', {
+    res.locals.headerData = {
+      caseloads,
       displayName: name,
       activeCaseLoad: caseloads.find(cl => cl.caseLoadId === activeCaseLoadId),
-    })
+    }
   }
   next()
 }

--- a/backend/middleware/currentUser.test.js
+++ b/backend/middleware/currentUser.test.js
@@ -3,13 +3,12 @@ const currentUser = require('./currentUser')
 describe('Current user', () => {
   const elite2Api = {}
   const oauthApi = {}
-  const njkEnv = {}
   let req
+  let res
 
   beforeEach(() => {
     elite2Api.userCaseLoads = jest.fn()
     oauthApi.currentUser = jest.fn()
-    njkEnv.addGlobal = jest.fn()
 
     oauthApi.currentUser.mockReturnValue({
       name: 'Bob Smith',
@@ -17,14 +16,15 @@ describe('Current user', () => {
     })
 
     req = { session: {} }
+    res = { locals: {} }
 
     elite2Api.userCaseLoads.mockReturnValue([{ caseLoadId: 'MDI', description: 'Moorland' }])
   })
 
   it('should request and store user details', async () => {
-    const controller = currentUser({ elite2Api, oauthApi, njkEnv })
+    const controller = currentUser({ elite2Api, oauthApi })
 
-    await controller(req, {}, () => {})
+    await controller(req, res, () => {})
 
     expect(oauthApi.currentUser).toHaveBeenCalled()
     expect(req.session.userDetails).toEqual({
@@ -34,20 +34,26 @@ describe('Current user', () => {
   })
 
   it('should request and store user case loads', async () => {
-    const controller = currentUser({ elite2Api, oauthApi, njkEnv })
+    const controller = currentUser({ elite2Api, oauthApi })
 
-    await controller(req, {}, () => {})
+    await controller(req, res, () => {})
 
     expect(elite2Api.userCaseLoads).toHaveBeenCalled()
     expect(req.session.allCaseloads).toEqual([{ caseLoadId: 'MDI', description: 'Moorland' }])
   })
 
-  it('should add njk global variables', async () => {
-    const controller = currentUser({ elite2Api, oauthApi, njkEnv })
+  it('should stash data into res.locals', async () => {
+    const controller = currentUser({ elite2Api, oauthApi })
 
-    await controller(req, {}, () => {})
+    await controller(req, res, () => {})
 
-    expect(njkEnv.addGlobal).toHaveBeenCalledWith('user', {
+    expect(res.locals.headerData).toEqual({
+      caseloads: [
+        {
+          caseLoadId: 'MDI',
+          description: 'Moorland',
+        },
+      ],
       activeCaseLoad: {
         caseLoadId: 'MDI',
         description: 'Moorland',
@@ -57,12 +63,12 @@ describe('Current user', () => {
   })
 
   it('ignore xhr requests', async () => {
-    const controller = currentUser({ elite2Api, oauthApi, njkEnv })
+    const controller = currentUser({ elite2Api, oauthApi })
     req.xhr = true
 
     const next = jest.fn()
 
-    await controller(req, {}, next)
+    await controller(req, res, next)
 
     expect(oauthApi.currentUser.mock.calls.length).toEqual(0)
     expect(elite2Api.userCaseLoads.mock.calls.length).toEqual(0)

--- a/backend/middleware/currentUser.test.js
+++ b/backend/middleware/currentUser.test.js
@@ -47,8 +47,8 @@ describe('Current user', () => {
 
     await controller(req, res, () => {})
 
-    expect(res.locals.headerData).toEqual({
-      caseloads: [
+    expect(res.locals.user).toEqual({
+      allCaseloads: [
         {
           caseLoadId: 'MDI',
           description: 'Moorland',

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -79,7 +79,6 @@ const setup = ({
   dataComplianceApi,
   keyworkerApi,
   caseNotesApi,
-  njkEnv,
 }) => {
   const controller = controllerFactory({
     activityListService: activityListFactory(elite2Api, whereaboutsApi, config),
@@ -99,7 +98,7 @@ const setup = ({
     elite2Api,
   })
 
-  router.use(currentUser({ elite2Api, oauthApi, njkEnv }))
+  router.use(currentUser({ elite2Api, oauthApi }))
 
   router.use(async (req, res, next) => {
     res.locals.currentUrlPath = req.originalUrl

--- a/views/partials/header.njk
+++ b/views/partials/header.njk
@@ -21,7 +21,7 @@
                         </div>
                         <div class="right-menu-dropdown-menu" id="menuItems">
                             <div>
-                            {% if allCaseloads.length > 1 %}
+                            {% if user.allCaseloads.length > 1 %}
                                 <a class="right-menu-dropdown-menu-option" href="/change-caseload">Change caseload</a>
                             {% endif %}
                             <a class="right-menu-dropdown-menu-option" href="/auth/logout">Sign out</a>


### PR DESCRIPTION
- Use res locals to store the user data because it has a request lifecycle. 