### PR TITLE
DCS-522 adding missing styles to new prisoner page

### DIFF
--- a/backend/shared/alertFlagValues.js
+++ b/backend/shared/alertFlagValues.js
@@ -86,14 +86,14 @@ module.exports = [
   },
   {
     alertCodes: ['URCU'],
-    classes: 'alert-status reverse-cohorting-unit',
+    classes: 'alert-status alert-status--reverse-cohorting-unit',
     label: 'Reverse Cohorting Unit',
   },
   {
     alertCodes: ['UPIU'],
-    classes: 'alert-status protective-isolation-unit',
+    classes: 'alert-status alert-status--protective-isolation-unit',
     label: 'Protective Isolation Unit',
   },
-  { alertCodes: ['USU'], classes: 'alert-status shielding-unit', label: 'Shielding Unit' },
-  { alertCodes: ['URS'], classes: 'alert-status refusing-to-shield', label: 'Refusing to shield' },
+  { alertCodes: ['USU'], classes: 'alert-status alert-status--shielding-unit', label: 'Shielding Unit' },
+  { alertCodes: ['URS'], classes: 'alert-status alert-status--refusing-to-shield', label: 'Refusing to shield' },
 ].sort((a, b) => a.label.localeCompare(b.label))

--- a/src/FullFlags/fullFlags.scss
+++ b/src/FullFlags/fullFlags.scss
@@ -116,6 +116,7 @@
     color: #FFF;
     border-color: mix(white, #00703C, 20%);
     background-color: mix(white, #00703C, 20%);
+    padding-bottom: 30px;
   }
   
   .protective-isolation-unit-status {
@@ -123,6 +124,7 @@
     color: #FFF;
     border-color: #006637;
     background-color: #006637;
+    padding-bottom: 30px;
   }
   
   .shielding-unit-status {
@@ -137,6 +139,7 @@
     color: #FFF;
     border-color: #B58840;
     background-color: #B58840;
+    padding-bottom: 30px;
   }
 
   @media (min-width: 481px) {


### PR DESCRIPTION
This rendered them in black and white:

<img width="351" alt="Screenshot 2020-06-08 at 09 56 25" src="https://user-images.githubusercontent.com/1517745/84013514-ec0e1a80-a970-11ea-81d2-dcaffb793889.png">


Also fixed padding on attendance screen:

was:
<kbd><img width="190" alt="Screenshot 2020-06-08 at 10 13 30" src="https://user-images.githubusercontent.com/1517745/84013541-f6301900-a970-11ea-9778-934475b2391b.png"></kbd>
 
now: 
<kbd>
<img width="193" alt="Screenshot 2020-06-08 at 10 14 20" src="https://user-images.githubusercontent.com/1517745/84013572-03e59e80-a971-11ea-916c-06fe1db51fa3.png"></kbd>

(typically only one alert of this type would be shown)