### PR TITLE
DCS-527 Hooking up covid unit pages to dashboard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ executors:
     working_directory: ~/app
   builder:
     docker:
-      - image: circleci/node:12.16.1-buster-browsers
+      - image: circleci/node:12-buster-browsers
     working_directory: ~/app
 
 orbs:

--- a/backend/controllers/covid/protectiveIsolationUnitController.js
+++ b/backend/controllers/covid/protectiveIsolationUnitController.js
@@ -31,7 +31,7 @@ module.exports = ({ covidService, logError, nowGetter = moment }) => {
       })
     } catch (e) {
       logError(req.originalUrl, e, 'Failed to load protective isolation list')
-      return res.render('error.njk', { url: '/protective-isolation-unit' })
+      return res.render('error.njk', { url: '/current-covid-units/protective-isolation-unit' })
     }
   }
 }

--- a/backend/controllers/covid/reverseCohortingUnit.js
+++ b/backend/controllers/covid/reverseCohortingUnit.js
@@ -32,7 +32,7 @@ module.exports = ({ covidService, logError }) => {
       })
     } catch (e) {
       logError(req.originalUrl, e, 'Failed to load reverse cohorting list')
-      return res.render('error.njk', { url: '/reverse-cohorting-unit' })
+      return res.render('error.njk', { url: '/current-covid-units/reverse-cohorting-unit' })
     }
   }
 }

--- a/backend/controllers/covid/shieldingUnitController.js
+++ b/backend/controllers/covid/shieldingUnitController.js
@@ -23,7 +23,7 @@ module.exports = ({ covidService, logError }) => {
       })
     } catch (e) {
       logError(req.originalUrl, e, 'Failed to load shielding list')
-      return res.render('error.njk', { url: '/shielding-unit' })
+      return res.render('error.njk', { url: '/current-covid-units/shielding-unit' })
     }
   }
 }

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -52,16 +52,12 @@ const requestBookingRouter = require('./routes/appointments/requestBookingRouter
 const prisonerProfileRouter = require('./routes/prisonerProfileRouter')
 const retentionReasonsRouter = require('./routes/retentionReasonsRouter')
 const attendanceChangeRouter = require('./routes/attendanceChangesRouter')
+const covidRouter = require('./routes/covidRouter')
 
 const prisonerSearchController = require('./controllers/search/prisonerSearch')
 const getExistingEventsController = require('./controllers/attendance/getExistingEvents')
 const getLocationExistingEventsController = require('./controllers/attendance/getLocationExistingEvents')
 const endDateController = require('./controllers/appointments/endDate')
-
-const covidDashboardController = require('./controllers/covid/covidDashboard')
-const reverseCohortingUnitController = require('./controllers/covid/reverseCohortingUnit')
-const protectiveIsolationUnitController = require('./controllers/covid/protectiveIsolationUnitController')
-const shieldingUnitController = require('./controllers/covid/shieldingUnitController')
 
 const currentUser = require('./middleware/currentUser')
 
@@ -264,11 +260,7 @@ const setup = ({
     prisonerProfileRouter({ elite2Api, keyworkerApi, oauthApi, caseNotesApi, logError })
   )
 
-  const covidService = covidServiceFactory(elite2Api)
-  router.use('/current-covid-units/', covidDashboardController({ covidService, logError }))
-  router.use('/reverse-cohorting-unit/', reverseCohortingUnitController({ covidService, logError }))
-  router.use('/protective-isolation-unit/', protectiveIsolationUnitController({ covidService, logError }))
-  router.use('/shielding-unit/', shieldingUnitController({ covidService, logError }))
+  router.use('/current-covid-units', covidRouter(elite2Api, logError))
 
   router.use('/attendance-changes', attendanceChangeRouter({ elite2Api, whereaboutsApi, oauthApi, logError }))
 

--- a/backend/routes/covidRouter.js
+++ b/backend/routes/covidRouter.js
@@ -1,0 +1,18 @@
+const express = require('express')
+const { covidServiceFactory } = require('../services/covidService')
+const covidDashboardController = require('../controllers/covid/covidDashboard')
+const reverseCohortingUnitController = require('../controllers/covid/reverseCohortingUnit')
+const protectiveIsolationUnitController = require('../controllers/covid/protectiveIsolationUnitController')
+const shieldingUnitController = require('../controllers/covid/shieldingUnitController')
+
+const router = express.Router({ mergeParams: true })
+
+module.exports = (elite2Api, logError) => {
+  const covidService = covidServiceFactory(elite2Api)
+
+  router.get('/', covidDashboardController({ covidService, logError }))
+  router.get('/reverse-cohorting-unit/', reverseCohortingUnitController({ covidService, logError }))
+  router.get('/protective-isolation-unit/', protectiveIsolationUnitController({ covidService, logError }))
+  router.get('/shielding-unit/', shieldingUnitController({ covidService, logError }))
+  return router
+}

--- a/backend/tests/protectiveIsolationUnitController.test.js
+++ b/backend/tests/protectiveIsolationUnitController.test.js
@@ -71,7 +71,7 @@ describe('protective isolation unit', () => {
     expect(res.render).toHaveBeenCalledWith(
       'error.njk',
       expect.objectContaining({
-        url: '/protective-isolation-unit',
+        url: '/current-covid-units/protective-isolation-unit',
       })
     )
   })

--- a/backend/tests/reverseCohortingUnitController.test.js
+++ b/backend/tests/reverseCohortingUnitController.test.js
@@ -68,7 +68,7 @@ describe('reverse cohorting unit', () => {
     expect(res.render).toHaveBeenCalledWith(
       'error.njk',
       expect.objectContaining({
-        url: '/reverse-cohorting-unit',
+        url: '/current-covid-units/reverse-cohorting-unit',
       })
     )
   })

--- a/backend/tests/shieldingUnitController.test.js
+++ b/backend/tests/shieldingUnitController.test.js
@@ -68,7 +68,7 @@ describe('shielding unit', () => {
     expect(res.render).toHaveBeenCalledWith(
       'error.njk',
       expect.objectContaining({
-        url: '/shielding-unit',
+        url: '/current-covid-units/shielding-unit',
       })
     )
   })

--- a/integration-tests/integration/covid/view-dashboard.spec.js
+++ b/integration-tests/integration/covid/view-dashboard.spec.js
@@ -1,13 +1,18 @@
 const DashboardPage = require('../../pages/covid/dashboardPage')
+const ReverseCohortingUnitPage = require('../../pages/covid/reverseCohortingUnitPage')
+const ProtectiveIsolationUnitPage = require('../../pages/covid/protectiveIsolationUnitPage')
+const ShieldingUnitPage = require('../../pages/covid/shieldingUnitPage')
 
 const alert = val => ({ alerts: { equalTo: val } })
 
-context('A user can view the covid dashboard page', () => {
-  before(() => {
+context('Covid dashboard page', () => {
+  beforeEach(() => {
     cy.clearCookies()
     cy.task('reset')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'WWI' })
     cy.login()
+
+    cy.task('stubAlerts', { locationId: 'MDI', alerts: [] })
 
     cy.task('stubInmates', { locationId: 'MDI', params: {}, count: 102 })
     cy.task('stubInmates', { locationId: 'MDI', params: alert('UPIU'), count: 8 })
@@ -20,9 +25,47 @@ context('A user can view the covid dashboard page', () => {
     const dashboardPage = DashboardPage.goTo()
 
     dashboardPage.prisonPopulation().contains(102)
+
     dashboardPage.reverseCohortingUnit().contains(12)
+    dashboardPage.reverseCohortingUnitLink().should('be.visible')
+
     dashboardPage.protectiveIsolationUnit().contains(8)
+    dashboardPage.protectiveIsolationUnitLink().should('be.visible')
+
     dashboardPage.shieldingUnit().contains(14)
+    dashboardPage.shieldingUnitLink().should('be.visible')
+
     dashboardPage.refusingToShield().contains('There are 5 prisoners who are refusing to shield')
+    dashboardPage.refusingToShieldLink().should('be.visible')
+  })
+
+  it('A user can navigate to the reverse cohorting unit', () => {
+    DashboardPage.goTo()
+      .reverseCohortingUnitLink()
+      .click()
+
+    ReverseCohortingUnitPage.verifyOnPage()
+  })
+
+  it('A user can navigate to the protective isolation unit', () => {
+    DashboardPage.goTo()
+      .protectiveIsolationUnitLink()
+      .click()
+
+    ProtectiveIsolationUnitPage.verifyOnPage()
+  })
+
+  it('A user can navigate to the shielding unit', () => {
+    DashboardPage.goTo()
+      .shieldingUnitLink()
+      .click()
+
+    ShieldingUnitPage.verifyOnPage()
+  })
+
+  it('A user can navigate to the refusing to shield list', () => {
+    DashboardPage.goTo()
+      .refusingToShieldLink()
+      .click()
   })
 })

--- a/integration-tests/pages/covid/dashboardPage.js
+++ b/integration-tests/pages/covid/dashboardPage.js
@@ -3,16 +3,24 @@ const page = require('../page')
 const dashboardPage = () =>
   page('Current breakdown of COVID units', {
     prisonPopulation: () => cy.get('[data-qa="prisonPopulation"]'),
+
     reverseCohortingUnit: () => cy.get('[data-qa="reverseCohortingUnit"]'),
+    reverseCohortingUnitLink: () => cy.get('[data-qa="reverseCohortingUnit-link"]'),
+
     protectiveIsolationUnit: () => cy.get('[data-qa="protectiveIsolationUnit"]'),
+    protectiveIsolationUnitLink: () => cy.get('[data-qa="protectiveIsolationUnit-link"]'),
+
     shieldingUnit: () => cy.get('[data-qa="shieldingUnit"]'),
+    shieldingUnitLink: () => cy.get('[data-qa="shieldingUnit-link"]'),
+
     refusingToShield: () => cy.get('[data-qa="refusingToShield"]'),
+    refusingToShieldLink: () => cy.get('[data-qa="refusingToShield-link"]'),
   })
 
 export default {
   verifyOnPage: dashboardPage,
   goTo: () => {
-    cy.visit('/current-covid-units')
+    cy.visit('/current-covid-units/')
     return dashboardPage()
   },
 }

--- a/integration-tests/pages/covid/protectiveIsolationUnitPage.js
+++ b/integration-tests/pages/covid/protectiveIsolationUnitPage.js
@@ -23,7 +23,7 @@ const protectiveIsolationUnitPage = () =>
 export default {
   verifyOnPage: protectiveIsolationUnitPage,
   goTo: () => {
-    cy.visit('/protective-isolation-unit')
+    cy.visit('/current-covid-units/protective-isolation-unit')
     return protectiveIsolationUnitPage()
   },
 }

--- a/integration-tests/pages/covid/reverseCohortingUnitPage.js
+++ b/integration-tests/pages/covid/reverseCohortingUnitPage.js
@@ -24,7 +24,7 @@ const reverseCohortingUnitPage = () =>
 export default {
   verifyOnPage: reverseCohortingUnitPage,
   goTo: () => {
-    cy.visit('/reverse-cohorting-unit')
+    cy.visit('/current-covid-units/reverse-cohorting-unit')
     return reverseCohortingUnitPage()
   },
 }

--- a/integration-tests/pages/covid/shieldingUnitPage.js
+++ b/integration-tests/pages/covid/shieldingUnitPage.js
@@ -22,7 +22,7 @@ const shieldingUnitPage = () =>
 export default {
   verifyOnPage: shieldingUnitPage,
   goTo: () => {
-    cy.visit('/shielding-unit')
+    cy.visit('/current-covid-units/shielding-unit')
     return shieldingUnitPage()
   },
 }

--- a/views/covid/dashboard.njk
+++ b/views/covid/dashboard.njk
@@ -15,6 +15,16 @@
     }) }}
 {% endblock %}
 
+{% macro conditionalCountLink(params) %}
+    {% if params.count > 0 %}
+      <a class="govuk-link govuk-body govuk-link--no-visited-state" data-qa="{{ params.name }}-link" href="{{params.page}}">
+        <span class="govuk-!-font-size-48 govuk-!-font-weight-bold" data-qa="{{ params.name }}">{{params.count}}</span>
+      </a>
+    {% else %}
+      <span class="govuk-body govuk-!-font-size-48 govuk-!-font-weight-bold" data-qa="{{ params.name }}">{{params.count}}</span>
+    {% endif %}
+{% endmacro %}
+
 {% block content %}
     <h1 class="govuk-heading-l">
         Current breakdown of COVID units
@@ -34,7 +44,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-quarter">
         <p class="govuk-body">Reverse Cohorting Unit</p>
-        <span class="govuk-body govuk-!-font-size-48 govuk-!-font-weight-bold" data-qa="reverseCohortingUnit">{{dashboardStats.reverseCohortingUnit}}</span>
+        {{ conditionalCountLink({ name: 'reverseCohortingUnit' , count: dashboardStats.reverseCohortingUnit, page: '/current-covid-units/reverse-cohorting-unit'}) }}
       </div>
     </div>
 
@@ -43,7 +53,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-quarter">
         <p class="govuk-body">Protective Isolation Unit</p>
-        <span class="govuk-body govuk-!-font-size-48 govuk-!-font-weight-bold" data-qa="protectiveIsolationUnit">{{dashboardStats.protectiveIsolationUnit}}</span>
+          {{ conditionalCountLink({ name: 'protectiveIsolationUnit' , count: dashboardStats.protectiveIsolationUnit, page: '/current-covid-units/protective-isolation-unit'}) }}
       </div>
     </div>
 
@@ -52,22 +62,23 @@
     <div class="govuk-grid-row">
       <div class="stat-with-warning">
         <p class="govuk-body">Shielding Unit</p>
-        <span class="govuk-body govuk-!-font-size-48 govuk-!-font-weight-bold" data-qa="shieldingUnit">{{dashboardStats.shieldingUnit}}</span>
+          {{ conditionalCountLink({ name: 'shieldingUnit' , count: dashboardStats.shieldingUnit, page: '/current-covid-units/shielding-unit'}) }}
       </div>
       <div class="govuk-grid-column-two-thirds">
         {% if dashboardStats.refusingToShield > 0 %}
           {% set message = "There is " + dashboardStats.refusingToShield + " prisoner refusing to shield" 
                   if dashboardStats.refusingToShield == 1 
                   else "There are " + dashboardStats.refusingToShield + " prisoners who are refusing to shield" %}
+          {% set messageAndLink = message + '<br/><a class="link govuk-body govuk-link--no-visited-state" data-qa="refusingToShield-link" href="/current-covid-units/refusing-to-shield">View prisoners</a>' %}        
           {{ govukWarningText({
-            text: message,
+            html: messageAndLink,
             iconFallbackText: "Warning",
             classes: "govuk-!-padding-top-9",
             attributes: {
               "data-qa": "refusingToShield"
             }
           }) }}
-        {% endif %}
+          {% endif %}
       </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
The numbers will only become links if there is at least one case.

Also moving all list page urls to a prefix of `/current-covid-units/`
(The dashboard which is currently on `/current-covid-units` will still be accessible on the original url so
the new-nomis url doesn't need to be updated)