### PR TITLE
DCS-539: warning icon made round using CSS

### DIFF
--- a/sass/_govuk-overrides.scss
+++ b/sass/_govuk-overrides.scss
@@ -65,5 +65,7 @@
   }
 }
 
-
-
+// to make the warning icon round
+.govuk-warning-text__icon {
+  box-sizing: content-box;
+}

--- a/sass/components/covid/dashboard.scss
+++ b/sass/components/covid/dashboard.scss
@@ -4,3 +4,9 @@
     width: 13%;
     float: left;
   }
+
+div[data-qa='refusingToShield'] .govuk-warning-text__icon {
+    padding-right: 10px;
+    padding-left: 10px;
+  }
+  

--- a/sass/components/covid/dashboard.scss
+++ b/sass/components/covid/dashboard.scss
@@ -4,9 +4,3 @@
     width: 13%;
     float: left;
   }
-
-div[data-qa='refusingToShield'] .govuk-warning-text__icon {
-    padding-right: 10px;
-    padding-left: 10px;
-  }
-  


### PR DESCRIPTION
Inserted CSS specifically for this element because there wasn't an option in the govuk warning component to target just the icon. Classes could be added to the component but only for the warning text not the icon.