### PR TITLE
DCS-535 Fixing the highlighting on the covid dashboard links

### DIFF
--- a/views/covid/dashboard.njk
+++ b/views/covid/dashboard.njk
@@ -17,8 +17,8 @@
 
 {% macro conditionalCountLink(params) %}
     {% if params.count > 0 %}
-      <a class="govuk-link govuk-body govuk-link--no-visited-state" data-qa="{{ params.name }}-link" href="{{params.page}}">
-        <span class="govuk-!-font-size-48 govuk-!-font-weight-bold" data-qa="{{ params.name }}">{{params.count}}</span>
+      <a class="govuk-link govuk-body govuk-link--no-visited-state govuk-!-font-size-48 govuk-!-font-weight-bold" data-qa="{{ params.name }}-link" href="{{params.page}}">
+        <span data-qa="{{ params.name }}">{{params.count}}</span>
       </a>
     {% else %}
       <span class="govuk-body govuk-!-font-size-48 govuk-!-font-weight-bold" data-qa="{{ params.name }}">{{params.count}}</span>


### PR DESCRIPTION
Before:
<kbd>
<img width="342" alt="Screenshot 2020-06-16 at 14 51 50" src="https://user-images.githubusercontent.com/1517745/84783557-52361580-afe1-11ea-8551-6df72df53fcb.png">
</kbd>

After:
<kbd>
<img width="263" alt="Screenshot 2020-06-16 at 14 55 08" src="https://user-images.githubusercontent.com/1517745/84783644-6417b880-afe1-11ea-8d91-51ca4a0ee42c.png">
</kbd>