### PR TITLE
NN-2740 Fix new prisoner search alert checkbox combo bugs

### DIFF
--- a/backend/controllers/search/prisonerSearch.js
+++ b/backend/controllers/search/prisonerSearch.js
@@ -12,14 +12,14 @@ module.exports = ({ paginationService, elite2Api, logError }) => async (req, res
   const {
     location,
     keywords,
-    alerts: queryAlerts,
+    alerts,
     pageOffsetOption,
     view,
     sortFieldsWithOrder = 'lastName,firstName:ASC',
   } = req.query
 
-  const multipleAlertsSelected = Array.isArray(queryAlerts)
-  const alerts = multipleAlertsSelected ? queryAlerts.map(alert => alert.split(',')).flat() : queryAlerts
+  const multipleAlertsSelected = Array.isArray(alerts)
+  const selectedAlerts = multipleAlertsSelected ? alerts.map(alert => alert.split(',')).flat() : alerts
 
   const pageOffset = (pageOffsetOption && parseInt(pageOffsetOption, 10)) || 0
   const pageLimit = 50
@@ -42,7 +42,7 @@ module.exports = ({ paginationService, elite2Api, logError }) => async (req, res
       elite2Api.userLocations(res.locals),
       elite2Api.getInmates(context, location || currentUserCaseLoad, {
         keywords,
-        alerts,
+        alerts: selectedAlerts,
         returnIep: 'true',
         returnAlerts: 'true',
         returnCategory: 'true',
@@ -65,12 +65,12 @@ module.exports = ({ paginationService, elite2Api, logError }) => async (req, res
       }))
 
     return res.render('prisonerSearch/prisonerSearch.njk', {
-      alertOptions: alertFlagValues.map(alertFlag => ({
-        value: alertFlag.alertCodes,
-        text: alertFlag.label,
+      alertOptions: alertFlagValues.map(({ alertCodes, label }) => ({
+        value: alertCodes,
+        text: label,
         checked: multipleAlertsSelected
-          ? alerts.some(alert => alertFlag.alertCodes.includes(alert))
-          : Boolean(alerts) && alertFlag.alertCodes.includes(alerts.split(',')[0]),
+          ? selectedAlerts.some(alert => alertCodes.includes(alert))
+          : Boolean(selectedAlerts) && alertCodes.includes(selectedAlerts.split(',')[0]),
       })),
       formValues: req.query,
       locationOptions,

--- a/backend/controllers/search/prisonerSearch.js
+++ b/backend/controllers/search/prisonerSearch.js
@@ -12,11 +12,14 @@ module.exports = ({ paginationService, elite2Api, logError }) => async (req, res
   const {
     location,
     keywords,
-    alerts,
+    alerts: queryAlerts,
     pageOffsetOption,
     view,
     sortFieldsWithOrder = 'lastName,firstName:ASC',
   } = req.query
+
+  const multipleAlertsSelected = Array.isArray(queryAlerts)
+  const alerts = multipleAlertsSelected ? queryAlerts.map(alert => alert.split(',')).flat() : queryAlerts
 
   const pageOffset = (pageOffsetOption && parseInt(pageOffsetOption, 10)) || 0
   const pageLimit = 50
@@ -65,7 +68,9 @@ module.exports = ({ paginationService, elite2Api, logError }) => async (req, res
       alertOptions: alertFlagValues.map(alertFlag => ({
         value: alertFlag.alertCodes,
         text: alertFlag.label,
-        checked: alertFlag.alertCodes.some(alert => alerts && alerts.includes(alert)),
+        checked: multipleAlertsSelected
+          ? alerts.some(alert => alertFlag.alertCodes.includes(alert))
+          : Boolean(alerts) && alertFlag.alertCodes.includes(alerts.split(',')[0]),
       })),
       formValues: req.query,
       locationOptions,

--- a/backend/tests/prisonerSearch.test.js
+++ b/backend/tests/prisonerSearch.test.js
@@ -130,8 +130,8 @@ describe('Prisoner search', () => {
     )
   })
 
-  it('should return correctly checked alert options', async () => {
-    req.query.alerts = ['HA', 'HA1']
+  it('should return correctly checked alert options when there is only one alert in the query', async () => {
+    req.query.alerts = 'HA'
 
     await controller(req, res)
 
@@ -141,8 +141,39 @@ describe('Prisoner search', () => {
         formValues: req.query,
         alertOptions: expect.arrayContaining([
           { checked: true, text: 'ACCT open', value: ['HA'] },
-          { checked: true, text: 'ACCT post closure', value: ['HA1'] },
+          { checked: false, text: 'ACCT post closure', value: ['HA1'] },
         ]),
+      })
+    )
+  })
+
+  it('should return correctly checked alert options when there are multiple alerts in the query', async () => {
+    req.query.alerts = ['HA1', 'RTP,RLG']
+
+    await controller(req, res)
+
+    expect(res.render).toHaveBeenCalledWith(
+      'prisonerSearch/prisonerSearch.njk',
+      expect.objectContaining({
+        formValues: req.query,
+        alertOptions: expect.arrayContaining([
+          { checked: true, text: 'ACCT post closure', value: ['HA1'] },
+          { checked: true, text: 'Risk to LGBT', value: ['RTP', 'RLG'] },
+        ]),
+      })
+    )
+  })
+
+  it('should return correctly checked alert option when one checkbox has multiple associated alert codes', async () => {
+    req.query.alerts = 'RTP,RLG'
+
+    await controller(req, res)
+
+    expect(res.render).toHaveBeenCalledWith(
+      'prisonerSearch/prisonerSearch.njk',
+      expect.objectContaining({
+        formValues: req.query,
+        alertOptions: expect.arrayContaining([{ checked: true, text: 'Risk to LGBT', value: ['RTP', 'RLG'] }]),
       })
     )
   })
@@ -251,8 +282,12 @@ describe('Prisoner search', () => {
     )
   })
 
-  it('should make make a call using the specified sorting options', async () => {
-    req.query.sortFieldsWithOrder = 'assignedLivingUnitDesc:DESC'
+  it('should make make a call to get inmates using the specified search and sorting options', async () => {
+    req.query = {
+      alerts: ['HA1', 'RTP,RLG'],
+      keywords: 'Smith',
+      sortFieldsWithOrder: 'assignedLivingUnitDesc:DESC',
+    }
 
     await controller(req, res)
 
@@ -265,7 +300,13 @@ describe('Prisoner search', () => {
         }),
       },
       'MDI',
-      { alerts: undefined, keywords: undefined, returnAlerts: 'true', returnCategory: 'true', returnIep: 'true' }
+      {
+        alerts: ['HA1', 'RTP', 'RLG'],
+        keywords: 'Smith',
+        returnAlerts: 'true',
+        returnCategory: 'true',
+        returnIep: 'true',
+      }
     )
   })
 


### PR DESCRIPTION
- Fix bug where a checked **ACCT open** `HA` would check both **ACCT Open** `HA` and **ACCT post closure** `HA1` on refresh but only search for **ACCT open** `HA`.
- Fix checkbox selection and API search bugs with checkboxes which have multiple associated alert codes. e.g. **Risk to LGBT** has codes `RTP` and `RLG`.