### PR TITLE
NN-2743: Update logging for 404s

### DIFF
--- a/backend/api/oauthEnabledClient.js
+++ b/backend/api/oauthEnabledClient.js
@@ -14,6 +14,15 @@ const resultLogger = result => {
 const errorLogger = error => {
   const status = error.response ? error.response.status : '-'
   const responseData = error.response ? error.response.body : '-'
+
+  // Not Found 404 is a valid response when querying for data.
+  // Log it for information and pass it down the line
+  // in case controllers want to do something specific.
+  if (status === 404) {
+    logger.warn(`${error.response.req.method} ${error.response.req.path} No record found`)
+    return error
+  }
+
   if (error.response && error.response.req) {
     logger.warn(
       `API error in ${error.response.req.method} ${error.response.req.path} ${status} ${error.message} ${responseData}`

--- a/backend/shared/logErrorAndContinue.js
+++ b/backend/shared/logErrorAndContinue.js
@@ -3,7 +3,12 @@ const log = require('../log')
 module.exports = apiCall =>
   new Promise(resolve => {
     apiCall.then(response => resolve(response)).catch(error => {
-      log.error(error)
+      // Not Found 404 is an acceptable response.
+      // It has been logged as part of the client call,
+      // no need to repeat here.
+      if (error.status !== 404) {
+        log.error(error)
+      }
       resolve(null)
     })
   })


### PR DESCRIPTION
404 Not found is a valid, non-error response, it means there is no accessible record for this information. Currently we're logging it like an error, which fills the error logs with noise. This updates the logging to remove the `error` wording, and in the case of the offender profile pages, not log anything additional to the client logging.