### PR TITLE
NN-2757 Updated criteria for what active contacts get shown

### DIFF
--- a/backend/tests/prisonerPersonal.test.js
+++ b/backend/tests/prisonerPersonal.test.js
@@ -1066,11 +1066,7 @@ describe('prisoner personal', () => {
               phones: [{ number: '02222222222', type: 'MOB' }, { number: '033333333333', type: 'MOB', ext: '777' }],
             })
             .mockResolvedValueOnce({
-              addresses: [
-                // { ...businessPrimary, endDate: '2020-01-01', addressType: 'Business' },
-                businessPrimary,
-                businessNonPrimary,
-              ],
+              addresses: [businessPrimary, businessNonPrimary],
               emails: [{ email: 'test3@email.com' }, { email: 'test4@email.com' }],
               phones: [{ number: '04444444444', type: 'MOB' }, { number: '055555555555', type: 'BUS', ext: '123' }],
             })

--- a/backend/tests/prisonerPersonal.test.js
+++ b/backend/tests/prisonerPersonal.test.js
@@ -918,6 +918,42 @@ describe('prisoner personal', () => {
       phones: [{ number: '011111111111', type: 'MOB' }],
     }
 
+    const businessPrimary = {
+      addressType: 'Business',
+      flat: '222',
+      premise: '999',
+      street: 'Business street',
+      town: 'London',
+      postalCode: 'W1 ABC',
+      county: 'London',
+      country: 'England',
+      comment: null,
+      primary: false,
+      noFixedAddress: false,
+      startDate: '2020-05-01',
+      endDate: null,
+      phones: [],
+      addressUsages: [],
+    }
+
+    const businessNonPrimary = {
+      addressType: 'Business',
+      flat: '222',
+      premise: '000',
+      street: 'Business street',
+      town: 'Manchester',
+      postalCode: 'W2 DEF',
+      county: 'Greater Manchester',
+      country: 'England',
+      comment: null,
+      primary: false,
+      noFixedAddress: false,
+      startDate: '2020-05-01',
+      endDate: null,
+      phones: [],
+      addressUsages: [],
+    }
+
     beforeEach(() => {
       elite2Api.getDetails.mockResolvedValue({ bookingId })
     })
@@ -1031,8 +1067,9 @@ describe('prisoner personal', () => {
             })
             .mockResolvedValueOnce({
               addresses: [
-                { ...primaryAddress, endDate: '2020-01-01', addressType: 'Business' },
-                { ...nonPrimaryAddress, addressType: 'Business' },
+                // { ...businessPrimary, endDate: '2020-01-01', addressType: 'Business' },
+                businessPrimary,
+                businessNonPrimary,
               ],
               emails: [{ email: 'test3@email.com' }, { email: 'test4@email.com' }],
               phones: [{ number: '04444444444', type: 'MOB' }, { number: '055555555555', type: 'BUS', ext: '123' }],
@@ -1085,17 +1122,83 @@ describe('prisoner personal', () => {
                     name: 'Uriualche Lydyle',
                     details: [
                       { label: 'Relationship', value: 'Case Administrator' },
-                      {
-                        label: 'Phone number',
-                        html: '04444444444,<br>055555555555 extension number 123',
-                      },
+                      { html: '04444444444,<br>055555555555 extension number 123', label: 'Phone number' },
                       { label: 'Email', value: 'test3@email.com, test4@email.com' },
-                      { label: 'Address', value: 'Flat B, 13, Another Street' },
+                      { label: 'Address', value: 'Flat 222, 999, Business street' },
+                      { label: 'Town', value: 'London' },
+                      { label: 'County', value: 'London' },
+                      { label: 'Postcode', value: 'W1 ABC' },
+                      { label: 'Country', value: 'England' },
+                      { html: '', label: 'Address phone' },
+                      { label: 'Address type', value: 'Business' },
+                    ],
+                  },
+                ],
+              },
+            })
+          )
+        })
+      })
+
+      describe('when there are multiple active addresses but no primary', () => {
+        beforeEach(() => {
+          personService.getPersonContactDetails
+            .mockResolvedValueOnce({
+              addresses: [
+                { ...nonPrimaryAddress, startDate: '2020-01-01', premise: 'Not latest active' },
+                { ...nonPrimaryAddress, startDate: '2020-01-02', premise: 'Latest active' },
+              ],
+              emails: [{ email: 'test1@email.com' }, { email: 'test2@email.com' }],
+              phones: [{ number: '02222222222', type: 'MOB' }, { number: '033333333333', type: 'MOB', ext: '777' }],
+            })
+            .mockResolvedValueOnce({
+              addresses: [
+                { ...businessNonPrimary, startDate: '2020-01-01', premise: 'Not latest active' },
+                { ...businessNonPrimary, startDate: '2020-01-02', premise: 'Latest active' },
+              ],
+              emails: [{ email: 'test3@email.com' }, { email: 'test4@email.com' }],
+              phones: [{ number: '04444444444', type: 'MOB' }, { number: '055555555555', type: 'BUS', ext: '123' }],
+            })
+        })
+
+        it('should render the template with the most recently added active address data', async () => {
+          await controller(req, res)
+
+          expect(res.render).toHaveBeenCalledWith(
+            'prisonerProfile/prisonerPersonal/prisonerPersonal.njk',
+            expect.objectContaining({
+              activeContacts: {
+                personal: [
+                  {
+                    name: 'John Smith',
+                    emergencyContact: true,
+                    details: [
+                      { label: 'Relationship', value: 'Cousin' },
+                      { html: '02222222222,<br>033333333333 extension number 777', label: 'Phone number' },
+                      { label: 'Email', value: 'test1@email.com, test2@email.com' },
+                      { label: 'Address', value: 'Flat B, Latest active, Another Street' },
                       { label: 'Town', value: 'Leeds' },
                       { label: 'County', value: 'West Yorkshire' },
                       { label: 'Postcode', value: 'LS2 BBB' },
                       { label: 'Country', value: 'England' },
-                      { label: 'Address phone', html: '011111111111' },
+                      { html: '011111111111', label: 'Address phone' },
+                      { label: 'Address type', value: 'Home' },
+                    ],
+                  },
+                ],
+                professional: [
+                  {
+                    name: 'Uriualche Lydyle',
+                    details: [
+                      { label: 'Relationship', value: 'Case Administrator' },
+                      { html: '04444444444,<br>055555555555 extension number 123', label: 'Phone number' },
+                      { label: 'Email', value: 'test3@email.com, test4@email.com' },
+                      { label: 'Address', value: 'Flat 222, Latest active, Business street' },
+                      { label: 'Town', value: 'Manchester' },
+                      { label: 'County', value: 'Greater Manchester' },
+                      { label: 'Postcode', value: 'W2 DEF' },
+                      { label: 'Country', value: 'England' },
+                      { html: '', label: 'Address phone' },
                       { label: 'Address type', value: 'Business' },
                     ],
                   },
@@ -1236,14 +1339,26 @@ describe('prisoner personal', () => {
             })
         })
 
-        it('should not return the professional contact', async () => {
+        it('should still return the professional contact', async () => {
           await controller(req, res)
 
           expect(res.render).toHaveBeenCalledWith(
             'prisonerProfile/prisonerPersonal/prisonerPersonal.njk',
             expect.objectContaining({
               activeContacts: expect.objectContaining({
-                professional: [],
+                professional: [
+                  {
+                    name: 'Uriualche Lydyle',
+                    details: [
+                      { label: 'Relationship', value: 'Case Administrator' },
+                      { label: 'Address', value: '' },
+                      { label: 'Town', value: undefined },
+                      { label: 'Postcode', value: undefined },
+                      { html: undefined, label: 'Address phone' },
+                      { label: 'Address type', value: undefined },
+                    ],
+                  },
+                ],
               }),
             })
           )


### PR DESCRIPTION
We only care about active addresses for a contact.  If there is an active address flagged as primary, show that, if not, show the most recently added active address.