### PR TITLE
DCS-573 COVID dashboard

### DIFF
--- a/backend/controllers/covid/covidDashboardController.js
+++ b/backend/controllers/covid/covidDashboardController.js
@@ -8,12 +8,14 @@ module.exports = ({ covidService, logError }) => {
       protectiveIsolationUnit,
       shieldingUnit,
       refusingToShield,
+      notInUnit,
     ] = await Promise.all([
       covidService.getCount(res),
       covidService.getCount(res, alerts.reverseCohortingUnit),
       covidService.getCount(res, alerts.protectiveIsolationUnit),
       covidService.getCount(res, alerts.shieldingUnit),
       covidService.getCount(res, alerts.refusingToShield),
+      covidService.getUnassignedNewEntrants(res),
     ])
 
     return {
@@ -22,6 +24,7 @@ module.exports = ({ covidService, logError }) => {
       protectiveIsolationUnit,
       shieldingUnit,
       refusingToShield,
+      notInUnitCount: notInUnit.length,
     }
   }
 

--- a/backend/services/covidService.js
+++ b/backend/services/covidService.js
@@ -8,83 +8,100 @@ const alerts = {
   refusingToShield: 'URS',
 }
 
+function hasCovidAlertByOffenderNo(alertsByOffenderNumber) {
+  return offenderNo => {
+    const alertsForOffender = alertsByOffenderNumber[offenderNo] || []
+    return alertsForOffender
+      .filter(({ expired }) => !expired)
+      .some(({ alertCode }) => Object.values(alerts).includes(alertCode))
+  }
+}
+
 module.exports = {
   alerts,
 
-  covidServiceFactory: (elite2Api, now = () => moment()) => ({
-    async getCount(res, alert) {
-      const { caseLoadId } = res.locals.user.activeCaseLoad
-
-      const context = { ...res.locals, requestHeaders: { 'page-offset': 0, 'page-limit': 1 } }
-
-      await elite2Api.getInmates(context, caseLoadId, alert ? { alerts: alert } : {})
-
-      return context.responseHeaders['total-records']
-    },
-
-    async getAlertList(res, code) {
-      const { caseLoadId } = res.locals.user.activeCaseLoad
-
-      const context = { ...res.locals, requestHeaders: { 'page-offset': 0, 'page-limit': 3000 } }
-
-      const inmates = await elite2Api.getInmates(context, caseLoadId, code ? { alerts: code } : {})
-
-      const offenderAlerts = await elite2Api.getAlerts(context, {
-        agencyId: caseLoadId,
-        offenderNumbers: inmates.map(inmate => inmate.offenderNo),
-      })
-
-      const inmateFor = offenderNo => inmates.find(inmate => inmate.offenderNo === offenderNo)
-
-      return offenderAlerts
-        .filter(({ alertCode }) => alertCode === code)
-        .filter(({ expired }) => !expired)
-        .map(alert => [alert, inmateFor(alert.offenderNo)])
-        .map(([alert, inmate]) => ({
-          bookingId: inmate.bookingId,
-          offenderNo: inmate.offenderNo,
-          name: putLastNameFirst(inmate.firstName, inmate.lastName),
-          assignedLivingUnitDesc: inmate.assignedLivingUnitDesc,
-          alertCreated: alert.dateCreated,
-        }))
-    },
-
-    async getUnassignedNewEntrants(res) {
-      const { caseLoadId } = res.locals.user.activeCaseLoad
-
-      const context = { ...res.locals, requestHeaders: { 'page-offset': 0, 'page-limit': 3000 } }
-
+  covidServiceFactory: (elite2Api, now = () => moment()) => {
+    async function getRecentMovements(context, caseLoadId) {
       const fourteenDaysAgo = now()
         .startOf('day')
         .subtract(14, 'days')
         .format('YYYY-MM-DDTHH:mm:ss')
-      const movements = await elite2Api.getMovementsInBetween(context, caseLoadId, { fromDateTime: fourteenDaysAgo })
 
+      return elite2Api.getMovementsInBetween(context, caseLoadId, { fromDateTime: fourteenDaysAgo })
+    }
+
+    async function getAlertsByOffenderNumber(context, caseLoadId, offenderNumbers) {
       const offenderAlerts = await elite2Api.getAlerts(context, {
         agencyId: caseLoadId,
-        offenderNumbers: movements.map(inmate => inmate.offenderNo),
+        offenderNumbers,
       })
 
-      const alertsByOffenderNumber = offenderAlerts.reduce((result, alert) => {
+      return offenderAlerts.reduce((result, alert) => {
         const bucket = result[alert.offenderNo] || []
         const newBucket = [...bucket, alert]
         return { ...result, [alert.offenderNo]: newBucket }
       }, {})
+    }
 
-      const isAssigned = offenderNo => {
-        const alertsForOffender = alertsByOffenderNumber[offenderNo] || []
-        return alertsForOffender
+    return {
+      async getCount(res, alert) {
+        const { caseLoadId } = res.locals.user.activeCaseLoad
+
+        const context = { ...res.locals, requestHeaders: { 'page-offset': 0, 'page-limit': 1 } }
+
+        await elite2Api.getInmates(context, caseLoadId, alert ? { alerts: alert } : {})
+
+        return context.responseHeaders['total-records']
+      },
+
+      async getAlertList(res, code) {
+        const { caseLoadId } = res.locals.user.activeCaseLoad
+
+        const context = { ...res.locals, requestHeaders: { 'page-offset': 0, 'page-limit': 3000 } }
+
+        const inmates = await elite2Api.getInmates(context, caseLoadId, code ? { alerts: code } : {})
+
+        const offenderAlerts = await elite2Api.getAlerts(context, {
+          agencyId: caseLoadId,
+          offenderNumbers: inmates.map(inmate => inmate.offenderNo),
+        })
+
+        const inmateFor = offenderNo => inmates.find(inmate => inmate.offenderNo === offenderNo)
+
+        return offenderAlerts
+          .filter(({ alertCode }) => alertCode === code)
           .filter(({ expired }) => !expired)
-          .some(({ alertCode }) => Object.values(alerts).includes(alertCode))
-      }
+          .map(alert => [alert, inmateFor(alert.offenderNo)])
+          .map(([alert, inmate]) => ({
+            bookingId: inmate.bookingId,
+            offenderNo: inmate.offenderNo,
+            name: putLastNameFirst(inmate.firstName, inmate.lastName),
+            assignedLivingUnitDesc: inmate.assignedLivingUnitDesc,
+            alertCreated: alert.dateCreated,
+          }))
+      },
 
-      return movements.filter(({ offenderNo }) => !isAssigned(offenderNo)).map(movement => ({
-        bookingId: movement.bookingId,
-        offenderNo: movement.offenderNo,
-        name: putLastNameFirst(movement.firstName, movement.lastName),
-        assignedLivingUnitDesc: movement.location,
-        arrivalDate: movement.movementDateTime,
-      }))
-    },
-  }),
+      async getUnassignedNewEntrants(res) {
+        const { caseLoadId } = res.locals.user.activeCaseLoad
+
+        const context = { ...res.locals, requestHeaders: { 'page-offset': 0, 'page-limit': 3000 } }
+        const recentMovements = await getRecentMovements(context, caseLoadId)
+        const alertsByOffenderNumber = await getAlertsByOffenderNumber(
+          context,
+          caseLoadId,
+          recentMovements.map(inmate => inmate.offenderNo)
+        )
+
+        const hasCovidAlert = hasCovidAlertByOffenderNo(alertsByOffenderNumber)
+
+        return recentMovements.filter(({ offenderNo }) => !hasCovidAlert(offenderNo)).map(movement => ({
+          bookingId: movement.bookingId,
+          offenderNo: movement.offenderNo,
+          name: putLastNameFirst(movement.firstName, movement.lastName),
+          assignedLivingUnitDesc: movement.location,
+          arrivalDate: movement.movementDateTime,
+        }))
+      },
+    }
+  },
 }

--- a/backend/tests/covidDashboardController.test.js
+++ b/backend/tests/covidDashboardController.test.js
@@ -17,6 +17,7 @@ describe('covid dashboard', () => {
 
     covidService = {
       getCount: jest.fn(),
+      getUnassignedNewEntrants: jest.fn(),
     }
     controller = covidDashboard({ covidService, logError })
   })
@@ -29,6 +30,8 @@ describe('covid dashboard', () => {
       .mockResolvedValueOnce(5)
       .mockResolvedValueOnce(14)
 
+    covidService.getUnassignedNewEntrants.mockResolvedValueOnce([{}, {}, {}])
+
     await controller(req, res)
 
     expect(logError).not.toHaveBeenCalled()
@@ -38,6 +41,7 @@ describe('covid dashboard', () => {
     expect(covidService.getCount).toHaveBeenCalledWith(res, 'UPIU')
     expect(covidService.getCount).toHaveBeenCalledWith(res, 'USU')
     expect(covidService.getCount).toHaveBeenCalledWith(res, 'URS')
+    expect(covidService.getUnassignedNewEntrants).toHaveBeenCalled()
 
     expect(res.render).toHaveBeenCalledWith(
       'covid/dashboard.njk',
@@ -48,6 +52,7 @@ describe('covid dashboard', () => {
           protectiveIsolationUnit: 9,
           shieldingUnit: 5,
           refusingToShield: 14,
+          notInUnitCount: 3,
         },
       })
     )

--- a/integration-tests/integration/covid/view-dashboard.spec.js
+++ b/integration-tests/integration/covid/view-dashboard.spec.js
@@ -1,6 +1,7 @@
 const moment = require('moment')
 const DashboardPage = require('../../pages/covid/dashboardPage')
 const ReverseCohortingUnitPage = require('../../pages/covid/reverseCohortingUnitPage')
+const NotInUnitPage = require('../../pages/covid/notInUnitPage')
 const ProtectiveIsolationUnitPage = require('../../pages/covid/protectiveIsolationUnitPage')
 const ShieldingUnitPage = require('../../pages/covid/shieldingUnitPage')
 const RefusingToShieldPage = require('../../pages/covid/refusingToShieldPage')
@@ -28,7 +29,32 @@ context('Covid dashboard page', () => {
         .startOf('day')
         .subtract(14, 'days')
         .format('YYYY-MM-DDTHH:mm:ss'),
-      movements: [],
+      movements: [
+        {
+          offenderNo: 'AA1234A',
+          bookingId: 123,
+          location: '1-2-017',
+          firstName: 'JAMES',
+          lastName: 'STEWART',
+          movementDateTime: '2020-01-04',
+        },
+        {
+          offenderNo: 'CC1234A',
+          bookingId: 234,
+          location: '1-2-018',
+          firstName: 'BOB',
+          lastName: 'SMITH',
+          movementDateTime: '2020-01-05',
+        },
+        {
+          offenderNo: 'DD1234A',
+          bookingId: 234,
+          location: '1-2-018',
+          firstName: 'JIM',
+          lastName: 'SMITH',
+          movementDateTime: '2020-01-05',
+        },
+      ],
     })
   })
 
@@ -39,6 +65,9 @@ context('Covid dashboard page', () => {
 
     dashboardPage.reverseCohortingUnit().contains(12)
     dashboardPage.reverseCohortingUnitLink().should('be.visible')
+
+    dashboardPage.notInUnit().contains(3)
+    dashboardPage.notInUnitLink().should('be.visible')
 
     dashboardPage.protectiveIsolationUnit().contains(8)
     dashboardPage.protectiveIsolationUnitLink().should('be.visible')
@@ -56,6 +85,14 @@ context('Covid dashboard page', () => {
       .click()
 
     ReverseCohortingUnitPage.verifyOnPage()
+  })
+
+  it('A user can navigate to the not in unit page', () => {
+    DashboardPage.goTo()
+      .notInUnitLink()
+      .click()
+
+    NotInUnitPage.verifyOnPage()
   })
 
   it('A user can navigate to the protective isolation unit', () => {

--- a/integration-tests/pages/covid/dashboardPage.js
+++ b/integration-tests/pages/covid/dashboardPage.js
@@ -7,6 +7,9 @@ const dashboardPage = () =>
     reverseCohortingUnit: () => cy.get('[data-qa="reverseCohortingUnit"]'),
     reverseCohortingUnitLink: () => cy.get('[data-qa="reverseCohortingUnit-link"]'),
 
+    notInUnit: () => cy.get('[data-qa=notInUnit]'),
+    notInUnitLink: () => cy.get('[data-qa=notInUnit-link]'),
+
     protectiveIsolationUnit: () => cy.get('[data-qa="protectiveIsolationUnit"]'),
     protectiveIsolationUnitLink: () => cy.get('[data-qa="protectiveIsolationUnit-link"]'),
 

--- a/sass/components/covid/dashboard.scss
+++ b/sass/components/covid/dashboard.scss
@@ -1,6 +1,5 @@
 .stat-with-warning {
     box-sizing: border-box;
     padding: 0 15px;
-    width: 13%;
     float: left;
   }

--- a/views/covid/dashboard.njk
+++ b/views/covid/dashboard.njk
@@ -1,5 +1,6 @@
 {% extends "../partials/layout.njk" %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "./macros.njk" import notInUnitWarning %}
 
 {% block beforeContent %}
     {{ govukBreadcrumbs({
@@ -42,10 +43,17 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-one-quarter">
+      <div class="govuk-grid-column-one-third">
         <p class="govuk-body">Reverse Cohorting Unit</p>
-        {{ conditionalCountLink({ name: 'reverseCohortingUnit' , count: dashboardStats.reverseCohortingUnit, page: '/current-covid-units/reverse-cohorting-unit'}) }}
       </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="stat-with-warning">
+            {{ conditionalCountLink({ name: 'reverseCohortingUnit' , count: dashboardStats.reverseCohortingUnit, page: '/current-covid-units/reverse-cohorting-unit'}) }}
+        </div>
+        <div class="govuk-grid-column-three-quarters">
+            {{ notInUnitWarning(dashboardStats.notInUnitCount) }}
+        </div>
     </div>
 
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
@@ -60,25 +68,28 @@
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     
     <div class="govuk-grid-row">
-      <div class="stat-with-warning">
+      <div class="govuk-grid-column-one-third">
         <p class="govuk-body">Shielding Unit</p>
-          {{ conditionalCountLink({ name: 'shieldingUnit' , count: dashboardStats.shieldingUnit, page: '/current-covid-units/shielding-unit'}) }}
       </div>
-      <div class="govuk-grid-column-two-thirds">
-        {% if dashboardStats.refusingToShield > 0 %}
-          {% set message = "There is " + dashboardStats.refusingToShield + " prisoner refusing to shield" 
-                  if dashboardStats.refusingToShield == 1 
-                  else "There are " + dashboardStats.refusingToShield + " prisoners who are refusing to shield" %}
-          {% set messageAndLink = message + '<br/><a class="link govuk-body govuk-link--no-visited-state" data-qa="refusingToShield-link" href="/current-covid-units/refusing-to-shield">View prisoners</a>' %}        
-          {{ govukWarningText({
-            html: messageAndLink,
-            iconFallbackText: "Warning",
-            classes: "govuk-!-padding-top-9",
-            attributes: {
-              "data-qa": "refusingToShield"
-            }
-          }) }}
-          {% endif %}
-      </div>
+    </div>
+    <div class="govuk-grid-row">
+        <div class="stat-with-warning">
+            {{ conditionalCountLink({ name: 'shieldingUnit' , count: dashboardStats.shieldingUnit, page: '/current-covid-units/shielding-unit'}) }}
+        </div>
+        <div class="govuk-grid-column-three-quarters">
+            {% if dashboardStats.refusingToShield > 0 %}
+                {% set message = "There is " + dashboardStats.refusingToShield + " prisoner refusing to shield"
+                    if dashboardStats.refusingToShield == 1
+                    else "There are " + dashboardStats.refusingToShield + " prisoners who are refusing to shield" %}
+                {% set messageAndLink = message + '<br/><a class="link govuk-body govuk-link--no-visited-state" data-qa="refusingToShield-link" href="/current-covid-units/refusing-to-shield">View prisoners</a>' %}
+                {{ govukWarningText({
+                    html: messageAndLink,
+                    iconFallbackText: "Warning",
+                    attributes: {
+                        "data-qa": "refusingToShield"
+                    }
+                }) }}
+            {% endif %}
+        </div>
     </div>
 {% endblock %}

--- a/views/covid/macros.njk
+++ b/views/covid/macros.njk
@@ -1,0 +1,17 @@
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+{% macro notInUnitWarning(notInUnitCount) %}
+    {% if notInUnitCount > 0 %}
+        {% set message = "There is 1 newly arrived prisoner who has not been added to this unit"
+            if notInUnitCount == 1
+            else "There are " + notInUnitCount + " newly arrived prisoners who have not been added to this unit" %}
+        {% set messageAndLink = message + '<br/><a class="link govuk-body govuk-link--no-visited-state" data-qa="notInUnit-link" href="/current-covid-units/not-in-unit">View prisoners</a>' %}
+        {{ govukWarningText({
+            html: messageAndLink,
+            iconFallbackText: "Warning",
+            attributes: {
+                "data-qa": "notInUnit"
+            }
+        }) }}
+    {% endif %}
+{% endmacro %}

--- a/views/covid/reverseCohortingUnit.njk
+++ b/views/covid/reverseCohortingUnit.njk
@@ -1,8 +1,6 @@
 {% extends "../partials/layout.njk" %}
-{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
-
+{% from "./macros.njk" import notInUnitWarning %}
 {% block beforeContent %}
     {{ govukBreadcrumbs({
         items: [
@@ -62,21 +60,8 @@
     <h1 class="govuk-heading-l">
         Prisoners in the Reverse Cohorting Unit
     </h1>
-    
 
-  {% if notInUnitCount > 0 %}
-    {% set message = "There is 1 newly arrived prisoner who has not been added to this unit"
-            if notInUnitCount == 1 
-            else "There are " + notInUnitCount + " newly arrived prisoners who have not been added to this unit" %}
-    {% set messageAndLink = message + '<br/><a class="link govuk-body govuk-link--no-visited-state" data-qa="notInUnit-link" href="/current-covid-units/not-in-unit">View prisoners</a>' %}        
-    {{ govukWarningText({
-      html: messageAndLink,
-      iconFallbackText: "Warning",
-      attributes: {
-        "data-qa": "notInUnit"
-      }
-    }) }}
-  {% endif %}
+  {{ notInUnitWarning(notInUnitCount) }}
 
   {% if rows.length %}
     <p class="govuk-body right-content">Prisoners listed: <strong><span data-qa="prisonerCount">{{ rows.length }}</span></strong></p>


### PR DESCRIPTION
* Show a warning for newly arrived prisoners who do not have a COVID alert.
* Link the warning to the not-in-unit page.