### PR TITLE
NN-2804 Remove visit details link temporarily

### DIFF
--- a/views/editAlertForm.njk
+++ b/views/editAlertForm.njk
@@ -145,7 +145,7 @@
               }
           },
           hint: {
-            text: "Closing this alert will change it to inactive and you cannot re-activate it"
+            text: "Closing this alert will change it to inactive and you cannot reactivate it"
           },
           errorMessage: errors | findError('alertStatus'),
           items: [

--- a/views/prisonerProfile/prisonerQuickLook/partials/visits.njk
+++ b/views/prisonerProfile/prisonerQuickLook/partials/visits.njk
@@ -43,7 +43,5 @@
             classes: "govuk-!-margin-bottom-2",
             attributes: { "data-test": "visits-summary" }
         }) }}
-
-        <a href="{{ '/prisoner/' + prisonerProfileData.offenderNo + '/visits' }}" class="govuk-link govuk-!-font-size-19">View visit details</a>
     {% endif %}
 </div>


### PR DESCRIPTION
- Remove **View visit details** link on prisoner profile so we can release new prisoner profile pages.
- Also changed **re-activated** to **reactivated**