### PR TITLE
NN-2806: Let views tackle missing data rather than controller

### DIFF
--- a/backend/controllers/prisonerProfile/prisonerQuickLook.js
+++ b/backend/controllers/prisonerProfile/prisonerQuickLook.js
@@ -109,13 +109,7 @@ module.exports = ({ prisonerProfileService, elite2Api, logError }) => async (req
 
       return res.render('prisonerProfile/prisonerQuickLook/prisonerQuickLook.njk', {
         dpsUrl,
-        prisonerProfileData: {
-          ...prisonerProfileData,
-          keyWorkerName: prisonerProfileData.keyWorkerName || 'None assigned',
-          keyWorkerLastSession: prisonerProfileData.keyWorkerLastSession || 'No previous session',
-          csra: prisonerProfileData.csra || 'Not entered',
-          category: prisonerProfileData.category || 'Not entered',
-        },
+        prisonerProfileData,
         offenceDetailsSectionError: Boolean(
           offenceDataResponse.error && prisonerDataResponse.error && sentenceDataResponse.error
         ),

--- a/backend/tests/prisonerQuickLook.test.js
+++ b/backend/tests/prisonerQuickLook.test.js
@@ -1187,7 +1187,7 @@ describe('prisoner profile quick look', () => {
       )
     })
 
-    it('should display correct defaults for offender profile data', async () => {
+    it('should pass nulls to frontend', async () => {
       prisonerProfileService.getPrisonerProfileData = jest.fn().mockResolvedValue({
         ...prisonerProfileData,
         keyWorkerName: null,
@@ -1205,12 +1205,12 @@ describe('prisoner profile quick look', () => {
             activeAlertCount: 1,
             agencyName: 'Moorland Closed',
             alerts: [],
-            category: 'Not entered',
-            csra: 'Not entered',
+            category: null,
+            csra: null,
             inactiveAlertCount: 2,
             incentiveLevel: 'Standard',
-            keyWorkerLastSession: 'No previous session',
-            keyWorkerName: 'None assigned',
+            keyWorkerLastSession: null,
+            keyWorkerName: null,
             location: 'CELL-123',
             offenderName: 'Prisoner, Test',
             offenderNo: 'ABC123',

--- a/views/macros/categoryFlag.njk
+++ b/views/macros/categoryFlag.njk
@@ -8,7 +8,7 @@
     {% elif categoryCode === 'P' %}
       CAT A Prov
     {% else %}
-      {{ categoryText | showDefault }}
+      {{ categoryText | showDefault('Not entered') }}
     {% endif %}
   {% endset %}
 

--- a/views/prisonerProfile/partials/prisonerProfileHeader.njk
+++ b/views/prisonerProfile/partials/prisonerProfileHeader.njk
@@ -2,11 +2,11 @@
 {% from "../../macros/alertFlags.njk" import alertFlags %}
 {% from "../../macros/categoryFlag.njk" import categoryFlag %}
 
-{% macro headerItem(label, content) %}
+{% macro headerItem(label, content, missingValue) %}
   <li>
     <strong>{{ label }}</strong>
     <br>
-    {{ content | showDefault | safe}}
+    {{ content | showDefault(missingValue or 'Not entered') | safe}}
   </li>
 {% endmacro %}
 
@@ -19,7 +19,7 @@
 {% endset %}
 
 {% set incentiveLevelHtml %}
-  <span>{{ prisonerProfileData.incentiveLevel | showDefault }}</span>
+  <span>{{ prisonerProfileData.incentiveLevel | showDefault('Not entered') }}</span>
   {% if prisonerProfileData.userCanEdit %}
     <br>
     <a data-qa="iep-details-link" class="govuk-link" href="{{ '/offenders/' + prisonerProfileData.offenderNo + '/incentive-level-details' }}">
@@ -68,8 +68,8 @@
 
     <ul class="prisoner-header__details__information">
       {{ headerItem('Prison number', prisonerProfileData.offenderNo) }}
-      {{ headerItem('Key worker', prisonerProfileData.keyWorkerName) }}
-      {{ headerItem('Last session', prisonerProfileData.keyWorkerLastSession) }}
+      {{ headerItem('Key worker', prisonerProfileData.keyWorkerName, 'None assigned') }}
+      {{ headerItem('Last session', prisonerProfileData.keyWorkerLastSession, 'No previous session') }}
       {{ headerItem('Incentive level', incentiveLevelHtml) }}
       {{ headerItem('CSRA', prisonerProfileData.csra) }}
       {{ headerItem('Category', categoryHtml) }}


### PR DESCRIPTION
The quicklook controller passed missing data values for some of the items in the header, while the rest of the controllers didn't. This resulted in a different missing value display depending on which tab you were on. This pulls the display logic entirely in the view by specifying the missing data value there and standardising controller behaviour.

![Screenshot from 2020-07-22 09-18-31](https://user-images.githubusercontent.com/4950775/88152768-6b436f00-cbfc-11ea-9de6-f94a5fa4f608.png)
