### PR TITLE
NN-2381 Make alerts query param in search url an array

### DIFF
--- a/backend/controllers/search/prisonerSearch.js
+++ b/backend/controllers/search/prisonerSearch.js
@@ -87,7 +87,7 @@ module.exports = ({ paginationService, elite2Api, logError }) => {
             .map(({ label }) => label),
         },
         results,
-        searchUrl: `${req.baseUrl}?${qs.stringify({ location, keywords, alerts, pageOffsetOption })}`,
+        searchUrl: `${req.baseUrl}?${qs.stringify({ location, keywords, 'alerts[]': alerts, pageOffsetOption })}`,
         totalRecords,
         view,
       })

--- a/backend/tests/prisonerSearch.test.js
+++ b/backend/tests/prisonerSearch.test.js
@@ -289,7 +289,7 @@ describe('Prisoner search', () => {
       expect(res.render).toHaveBeenCalledWith(
         'prisonerSearch/prisonerSearch.njk',
         expect.objectContaining({
-          searchUrl: '/prisoner-search?location=MDI&keywords=Smith&alerts=HA&alerts=HA1&pageOffsetOption=',
+          searchUrl: '/prisoner-search?location=MDI&keywords=Smith&alerts%5B%5D=HA&alerts%5B%5D=HA1&pageOffsetOption=',
           view: 'grid',
           printedValues: {
             alerts: ['ACCT open', 'ACCT post closure'],


### PR DESCRIPTION
Search results breaking when changing from list view to grid view because the alerts params were not an array.