### PR TITLE
DCS-582 COVID - Dates are in the incorrect format on the units

### DIFF
--- a/integration-tests/integration/covid/view-not-in-unit-list.spec.js
+++ b/integration-tests/integration/covid/view-not-in-unit-list.spec.js
@@ -101,7 +101,7 @@ context('A user can view the protective isolation list', () => {
       prisoner().contains('Read, Donna')
       prisonNumber().contains('BB1234A')
       location().contains('1-2-018')
-      arrivalDate().contains('5 Jan 2020')
+      arrivalDate().contains('5 January 2020')
     }
 
     {
@@ -110,7 +110,7 @@ context('A user can view the protective isolation list', () => {
       prisoner().contains('Stewart, James')
       prisonNumber().contains('AA1234A')
       location().contains('1-2-017')
-      arrivalDate().contains('4 Jan 2020')
+      arrivalDate().contains('4 January 2020')
     }
   })
 })

--- a/integration-tests/integration/covid/view-protective-isolation-list.spec.js
+++ b/integration-tests/integration/covid/view-protective-isolation-list.spec.js
@@ -59,7 +59,7 @@ context('A user can view the protective isolation list', () => {
       prisoner().contains('Read, Donna')
       prisonNumber().contains('BB1234A')
       location().contains('1-2-018')
-      dateAdded().contains(dayBeforeYesterday.format('D MMM YYYY'))
+      dateAdded().contains(dayBeforeYesterday.format('D MMMM YYYY'))
       daysInUnit().contains(2)
     }
 
@@ -69,7 +69,7 @@ context('A user can view the protective isolation list', () => {
       prisoner().contains('Stewart, James')
       prisonNumber().contains('AA1234A')
       location().contains('1-2-017')
-      dateAdded().contains(moment().format('D MMM YYYY'))
+      dateAdded().contains(moment().format('D MMMM YYYY'))
       daysInUnit().contains(0)
     }
   })

--- a/integration-tests/integration/covid/view-reverse-cohorting-list.spec.js
+++ b/integration-tests/integration/covid/view-reverse-cohorting-list.spec.js
@@ -97,8 +97,8 @@ context('A user can view the reverse cohorting list', () => {
       prisoner().contains('Stewart, James')
       prisonNumber().contains('BB1234A')
       location().contains('1-2-017')
-      dateAdded().contains('3 Jan 2020')
-      dateOverdue().contains('17 Jan 2020')
+      dateAdded().contains('3 January 2020')
+      dateOverdue().contains('17 January 2020')
       overdue().should('be.visible')
     }
 
@@ -108,8 +108,8 @@ context('A user can view the reverse cohorting list', () => {
       prisoner().contains('Read, Donna')
       prisonNumber().contains('AA1234A')
       location().contains('1-2-018')
-      dateAdded().contains(dayBeforeYesterday.format('D MMM YYYY'))
-      dateOverdue().contains(dayBeforeYesterdayOverDue.format('D MMM YYYY'))
+      dateAdded().contains(dayBeforeYesterday.format('D MMMM YYYY'))
+      dateOverdue().contains(dayBeforeYesterdayOverDue.format('D MMMM YYYY'))
       overdue().should('not.be.visible')
     }
   })

--- a/integration-tests/integration/covid/view-shielding-list.spec.js
+++ b/integration-tests/integration/covid/view-shielding-list.spec.js
@@ -59,7 +59,7 @@ context('A user can view the protective isolation list', () => {
       prisoner().contains('Read, Donna')
       prisonNumber().contains('BB1234A')
       location().contains('1-2-018')
-      dateAdded().contains(dayBeforeYesterday.format('D MMM YYYY'))
+      dateAdded().contains(dayBeforeYesterday.format('D MMMM YYYY'))
     }
 
     {
@@ -68,7 +68,7 @@ context('A user can view the protective isolation list', () => {
       prisoner().contains('Stewart, James')
       prisonNumber().contains('AA1234A')
       location().contains('1-2-017')
-      dateAdded().contains(moment().format('D MMM YYYY'))
+      dateAdded().contains(moment().format('D MMMM YYYY'))
     }
   })
 })

--- a/views/covid/notInUnit.njk
+++ b/views/covid/notInUnit.njk
@@ -37,7 +37,7 @@
           text: result.assignedLivingUnitDesc
         },
         {
-          text: result.arrivalDate | formatDate('D MMM YYYY'),
+          text: result.arrivalDate | formatDate('D MMMM YYYY'),
           attributes: {
             "data-sort-value": result.arrivalDate | formatDate('X')
           }

--- a/views/covid/protectiveIsolationUnit.njk
+++ b/views/covid/protectiveIsolationUnit.njk
@@ -37,7 +37,7 @@
           text: result.assignedLivingUnitDesc
         },
         {
-          text: result.alertCreated | formatDate('D MMM YYYY'),
+          text: result.alertCreated | formatDate('D MMMM YYYY'),
           attributes: {
             "data-sort-value": result.alertCreated | formatDate('X')
           }

--- a/views/covid/reverseCohortingUnit.njk
+++ b/views/covid/reverseCohortingUnit.njk
@@ -36,13 +36,13 @@
           text: result.assignedLivingUnitDesc
         },
         {
-          text: result.alertCreated | formatDate('D MMM YYYY'),
+          text: result.alertCreated | formatDate('D MMMM YYYY'),
           attributes: {
             "data-sort-value": result.alertCreated | formatDate('X')
           }
         },
         {
-          text: result.expectedMoveDate | formatDate('D MMM YYYY'),
+          text: result.expectedMoveDate | formatDate('D MMMM YYYY'),
           attributes: {
             "data-sort-value": result.expectedMoveDate | formatDate('X')
           }

--- a/views/covid/shieldingUnit.njk
+++ b/views/covid/shieldingUnit.njk
@@ -37,7 +37,7 @@
           text: result.assignedLivingUnitDesc
         },
         {
-          text: result.alertCreated | formatDate('D MMM YYYY'),
+          text: result.alertCreated | formatDate('D MMMM YYYY'),
           attributes: {
             "data-sort-value": result.alertCreated | formatDate('X')
           }


### PR DESCRIPTION
Dates were using shortened month names (Jan, Feb, ...)
Changed to use  full month name. For example 2 December 2020.
These changes affect date display in the Covid pages only.