### PR TITLE
PAT-1216: Updated URLs for SOC for altered domain name

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -41,7 +41,7 @@ env:
   PATHFINDER_UI_URL: https://dev.pathfinder.service.justice.gov.uk/
   PATHFINDER_ENDPOINT_API_URL: https://dev-api.pathfinder.service.justice.gov.uk/
   REDIS_ENABLED: true
-  SOC_URL: https://manage-soc-cases-dev.service.justice.gov.uk
+  SOC_URL: https://manage-soc-cases-dev.hmpps.service.justice.gov.uk
   SOC_API_ENABLED: true
   OFFENDER_SEARCH_API_URL: https://prisoner-offender-search-dev.prison.service.justice.gov.uk
   OFFENDER_SEARCH_API_ENABLED: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -41,7 +41,7 @@ env:
   PATHFINDER_ENDPOINT_API_URL: https://preprod-api.pathfinder.service.justice.gov.uk/
   REDIS_ENABLED: true
   SOC_URL: https://manage-soc-cases-preprod.hmpps.service.justice.gov.uk
-  SOC_API_ENABLED: false
+  SOC_API_ENABLED: true
   OFFENDER_SEARCH_API_URL: https://prisoner-offender-search-preprod.prison.service.justice.gov.uk
   OFFENDER_SEARCH_API_ENABLED: true
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -40,7 +40,7 @@ env:
   PATHFINDER_UI_URL: https://preprod.pathfinder.service.justice.gov.uk/
   PATHFINDER_ENDPOINT_API_URL: https://preprod-api.pathfinder.service.justice.gov.uk/
   REDIS_ENABLED: true
-  SOC_URL: https://manage-soc-cases-preprod.service.justice.gov.uk
+  SOC_URL: https://manage-soc-cases-preprod.hmpps.service.justice.gov.uk
   SOC_API_ENABLED: false
   OFFENDER_SEARCH_API_URL: https://prisoner-offender-search-preprod.prison.service.justice.gov.uk
   OFFENDER_SEARCH_API_ENABLED: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -39,7 +39,7 @@ env:
   PATHFINDER_UI_URL: https://pathfinder.service.justice.gov.uk/
   PATHFINDER_ENDPOINT_API_URL: https://api.pathfinder.service.justice.gov.uk/
   REDIS_ENABLED: true
-  SOC_URL: https://manage-soc-cases.service.justice.gov.uk
+  SOC_URL: https://manage-soc-cases.hmpps.service.justice.gov.uk
   SOC_API_ENABLED: false
   OFFENDER_SEARCH_API_URL: https://prisoner-offender-search.prison.service.justice.gov.uk
   OFFENDER_SEARCH_API_ENABLED: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -40,7 +40,7 @@ env:
   PATHFINDER_ENDPOINT_API_URL: https://api.pathfinder.service.justice.gov.uk/
   REDIS_ENABLED: true
   SOC_URL: https://manage-soc-cases.hmpps.service.justice.gov.uk
-  SOC_API_ENABLED: false
+  SOC_API_ENABLED: true
   OFFENDER_SEARCH_API_URL: https://prisoner-offender-search.prison.service.justice.gov.uk
   OFFENDER_SEARCH_API_ENABLED: true
 


### PR DESCRIPTION
URL changes for manage-soc-services - updated to use the .hmpps.service.justice.gov.uk domain in all environments and set the enabled flags so that the links will show where the current user has a SOC role in their token.