### PR TITLE
Nn 2908 cell history tweaks

### DIFF
--- a/backend/controllers/attendance/attendanceStatistics.js
+++ b/backend/controllers/attendance/attendanceStatistics.js
@@ -76,7 +76,9 @@ const absentReasonTableViewModel = offenderData => ({
       return [
         {
           html: data.location
-            ? `<a href=${quickLookUrl} class="govuk-link" target="_blank">${data.offenderName}</a>`
+            ? `<a href=${quickLookUrl} class="govuk-link" target="_blank" rel="noopener noreferrer">${
+                data.offenderName
+              }</a>`
             : data.offenderName,
         },
         {

--- a/backend/tests/attendanceStatistics.test.js
+++ b/backend/tests/attendanceStatistics.test.js
@@ -511,7 +511,8 @@ describe('Attendance reason statistics', () => {
         offenders: [
           [
             {
-              html: '<a href=/prisoner/G8974UK class="govuk-link" target="_blank">Smith, Adam</a>',
+              html:
+                '<a href=/prisoner/G8974UK class="govuk-link" target="_blank" rel="noopener noreferrer">Smith, Adam</a>',
             },
             { text: 'G8974UK' },
             { text: '1' },

--- a/views/bulkAppointmentsAdded.njk
+++ b/views/bulkAppointmentsAdded.njk
@@ -34,7 +34,7 @@
       {% endif %}
 
       <p class="govuk-body">
-        <a href="/bulk-appointments/appointments-movement-slips" class="govuk-link govuk-link--no-visited-state" target="_blank" data-qa="print-movement-slips">
+        <a href="/bulk-appointments/appointments-movement-slips" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer" data-qa="print-movement-slips">
           Print movement authorisation slips
         </a>
       </p>

--- a/views/cellMove/offenderDetails.njk
+++ b/views/cellMove/offenderDetails.njk
@@ -89,7 +89,7 @@
   </p>
 
   <p class="govuk-body govuk-!-margin-top-4">
-    <a class="govuk-link" href={{ profileUrl }} target="_blank" data-test="profile-link">View full profile (opens in a new tab)</a>
+    <a class="govuk-link" href={{ profileUrl }} target="_blank" rel="noopener noreferrer" data-test="profile-link">View full profile (opens in a new tab)</a>
   </p>
   
 {% endblock %}

--- a/views/confirmAppointments.njk
+++ b/views/confirmAppointments.njk
@@ -28,7 +28,7 @@
             }) }}
 
             <p class="govuk-body">
-                <a href="/bulk-appointments/appointments-movement-slips" class="govuk-link govuk-link--no-visited-state" target="_blank" data-qa="print-movement-slips">
+                <a href="/bulk-appointments/appointments-movement-slips" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer" data-qa="print-movement-slips">
                     Print movement slip
                 </a>
             </p>

--- a/views/prisonerProfile/partials/prisonerProfileHeader.njk
+++ b/views/prisonerProfile/partials/prisonerProfileHeader.njk
@@ -43,6 +43,10 @@
   {{ prisonerProfileData.location}}
   <br>
   {{ prisonerProfileData.agencyName}}
+  <br>
+  <a data-qa="cell-history-link" class="govuk-link" href="{{ '/prisoner/' + prisonerProfileData.offenderNo + '/cell-history' }}">
+      View details
+    </a>
 {% endset %}
 
 <div class="header-with-link">

--- a/views/prisonerProfile/partials/prisonerProfileHeader.njk
+++ b/views/prisonerProfile/partials/prisonerProfileHeader.njk
@@ -86,13 +86,13 @@
 
     <div class="prisoner-header__details__actions">
         {% if prisonerProfileData.showPathfinderReferButton %}
-            <a  href="{{ prisonerProfileData.pathfinderReferUrl }}" class="govuk-button govuk-button--link govuk-!-margin-bottom-3" data-module="govuk-button" target="_blank">
+            <a  href="{{ prisonerProfileData.pathfinderReferUrl }}" class="govuk-button govuk-button--link govuk-!-margin-bottom-3" data-module="govuk-button" target="_blank" rel="noopener noreferrer">
                 Refer to Pathfinder
             </a>
         {% endif %}
 
         {% if prisonerProfileData.showSocReferButton %}
-            <a  href="{{ prisonerProfileData.socReferUrl }}" class="govuk-button govuk-button--link govuk-!-margin-bottom-3" data-module="govuk-button" target="_blank" data-test="soc-referral-button">
+            <a  href="{{ prisonerProfileData.socReferUrl }}" class="govuk-button govuk-button--link govuk-!-margin-bottom-3" data-module="govuk-button" target="_blank"  rel="noopener noreferrer" data-test="soc-referral-button">
                 Refer to SOC
             </a>
         {% endif %}

--- a/views/prisonerProfile/prisonerCaseNotes/caseNotes.njk
+++ b/views/prisonerProfile/prisonerCaseNotes/caseNotes.njk
@@ -33,7 +33,7 @@
         {% if caseNote.caseNoteDetailColumn.printIncentiveLink %}
             <p class="govuk-body">
                 <a class="govuk-link" data-test="print-slip"
-                href={{ caseNote.caseNoteDetailColumn.printIncentiveLink }} target="_blank">
+                href={{ caseNote.caseNoteDetailColumn.printIncentiveLink }} target="_blank" rel="noopener noreferrer">
                     Print Incentive Level slip
                 </a>
             <p>

--- a/views/prisonerProfile/prisonerCellHistory.njk
+++ b/views/prisonerProfile/prisonerCellHistory.njk
@@ -44,10 +44,10 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
+    <div class="govuk-grid-column-three-quarters">
       <h1 class="govuk-heading-l">{{titleWithName | safe}}</h1>
     </div>
-    <div class="govuk-grid-column-one-half pull-right">
+    {# <div class="govuk-grid-column-one-quarter pull-right">
       {{ govukButton({
         href: changeCellLink,
         text: "Change cell",
@@ -57,7 +57,7 @@
           "data-test": 'cell-move-button'
         }
         }) }}
-    </div>
+    </div> #}
   </div>
   <h2 class="govuk-heading-m">Current location</h2>
     <div class="cell-history-header govuk-!-margin-bottom-7">
@@ -116,9 +116,9 @@
           </div>
           <div class="govuk-grid-column-one-half">
           <p class="govuk-body">
-            <a href="{{ './location-history?fromDate=' + currentLocation.assignmentDate + '&locationId=' + currentLocation.livingUnitId + '&agencyId=' + currentLocation.agencyId }}" class="govuk-link" data-test="cell-details-link">
+            {# <a href="{{ './location-history?fromDate=' + currentLocation.assignmentDate + '&locationId=' + currentLocation.livingUnitId + '&agencyId=' + currentLocation.agencyId }}" class="govuk-link" data-test="cell-details-link">
               View details
-            </a>
+            </a> #}
           </p>
           </div>
         </div>

--- a/views/prisonerProfile/prisonerLocationHistory.njk
+++ b/views/prisonerProfile/prisonerLocationHistory.njk
@@ -62,7 +62,7 @@
   {% for prisoner in locationSharingHistory %}
     {% set rows = (rows.push([  
       {
-        html: '<a href="/prisoner/' + prisoner.number + '" class="govuk-link" target="_blank">' + prisoner.name + ' (opens in a new tab)</a>' if prisoner.shouldLink,
+        html: '<a href="/prisoner/' + prisoner.number + '" class="govuk-link" target="_blank" rel="noopener noreferrer">' + prisoner.name + ' (opens in a new tab)</a>' if prisoner.shouldLink,
         text: prisoner.name
       },
       {

--- a/views/videolinkBookingConfirmHearingPrison.njk
+++ b/views/videolinkBookingConfirmHearingPrison.njk
@@ -40,7 +40,7 @@
     }) }}
 
     <p class="govuk-body">
-        <a href="/bulk-appointments/appointments-movement-slips" class="govuk-link govuk-link--no-visited-state" target="_blank" data-qa="print-movement-slips">
+        <a href="/bulk-appointments/appointments-movement-slips" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer" data-qa="print-movement-slips">
             Print movement slip
         </a>
     </p>


### PR DESCRIPTION
The button is currently hidden so you can't see that the wrapping has changed. Below are screenshots of the wrapping before and after change with the button present for the same window size.
<img width="1031" alt="Screenshot 2020-09-09 at 08 20 12" src="https://user-images.githubusercontent.com/4950775/92568167-afef9c00-f276-11ea-8e4c-5dfb656c5874.png">
<img width="1031" alt="Screenshot 2020-09-09 at 08 20 17" src="https://user-images.githubusercontent.com/4950775/92568186-b5e57d00-f276-11ea-8fa9-56ad65982571.png">

Also adding rel="noopener noreferer" to target="_blank" to follow best security practices.
