### PR TITLE
Nn 2716 fix category warning

### DIFF
--- a/backend/controllers/cellMove/moveValidation.js
+++ b/backend/controllers/cellMove/moveValidation.js
@@ -174,6 +174,7 @@ const moveValidationFactory = ({ elite2Api, logError }) => {
         currentOffenderActiveAlerts,
         currentOccupantsActiveAlerts,
         categoryWarning,
+        showRisks: currentOffenderActiveAlerts.length > 0 || currentOccupantsActiveAlerts.length > 0 || categoryWarning,
         errors,
         dpsUrl,
       })

--- a/backend/controllers/cellMove/moveValidation.js
+++ b/backend/controllers/cellMove/moveValidation.js
@@ -154,7 +154,7 @@ const moveValidationFactory = ({ elite2Api, logError }) => {
         )
         .flatMap(alert => alert)
 
-      const categoryWarning = currentOffenderDetails.categoryCode === 'A'
+      const categoryWarning = currentOccupantsDetails.length > 0 && currentOffenderDetails.categoryCode === 'A'
 
       if (
         !categoryWarning &&

--- a/backend/tests/cellMove/moveValidation.test.js
+++ b/backend/tests/cellMove/moveValidation.test.js
@@ -385,6 +385,7 @@ describe('move validation', () => {
         offenderNo,
         csraWarningMessage: 'who is CSRA high into a cell with a prisoner who is CSRA high',
         categoryWarning: true,
+        showRisks: true,
         nonAssociations: [
           {
             name: 'Bloggs, Jim',
@@ -454,6 +455,7 @@ describe('move validation', () => {
       'cellMove/moveValidation.njk',
       expect.objectContaining({
         csraWarningMessage: 'who is CSRA standard into a cell with a prisoner who is CSRA high',
+        showRisks: true,
         currentOffenderActiveAlerts: [
           {
             comment: 'has a large poster on cell wall',
@@ -499,12 +501,17 @@ describe('move validation', () => {
       'cellMove/moveValidation.njk',
       expect.objectContaining({
         csraWarningMessage: null,
+        showRisks: true,
       })
     )
   })
 
   it('Does not pass alerts and CSRA when there are no occupants', async () => {
-    elite2Api.getDetails.mockResolvedValueOnce({ ...getCurrentOffenderDetailsResponse, csra: 'Standard' })
+    elite2Api.getDetails.mockResolvedValueOnce({
+      ...getCurrentOffenderDetailsResponse,
+      csra: 'Standard',
+      categoryCode: 'C',
+    })
     elite2Api.getLocation
       .mockResolvedValueOnce(cellLocationData)
       .mockResolvedValueOnce(parentLocationData)
@@ -518,6 +525,8 @@ describe('move validation', () => {
         csraWarningMessage: false,
         currentOffenderActiveAlerts: false,
         currentOccupantsActiveAlerts: [],
+        categoryWarning: false,
+        showRisks: false,
       })
     )
   })
@@ -535,6 +544,7 @@ describe('move validation', () => {
       'cellMove/moveValidation.njk',
       expect.objectContaining({
         categoryWarning: false,
+        showRisks: false,
       })
     )
   })

--- a/backend/tests/cellMove/moveValidation.test.js
+++ b/backend/tests/cellMove/moveValidation.test.js
@@ -522,6 +522,23 @@ describe('move validation', () => {
     )
   })
 
+  it('Does not pass category warning if no inmates', async () => {
+    elite2Api.getDetails.mockResolvedValueOnce({ ...getCurrentOffenderDetailsResponse, csra: 'Standard' })
+    elite2Api.getLocation
+      .mockResolvedValueOnce(cellLocationData)
+      .mockResolvedValueOnce(parentLocationData)
+      .mockResolvedValueOnce(superParentLocationData)
+    elite2Api.getInmatesAtLocation.mockResolvedValue([])
+    await controller.index(req, res)
+
+    expect(res.render).toHaveBeenCalledWith(
+      'cellMove/moveValidation.njk',
+      expect.objectContaining({
+        categoryWarning: false,
+      })
+    )
+  })
+
   it('Redirects when form has been triggered with no data', async () => {
     elite2Api.getDetails
       .mockResolvedValueOnce(getCurrentOffenderDetailsResponse)

--- a/views/cellMove/moveValidation.njk
+++ b/views/cellMove/moveValidation.njk
@@ -109,7 +109,7 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
   {% endif %}
 
 
-  {% if currentOffenderActiveAlerts.length or currentOccupantsActiveAlerts.length or categoryWarning %}
+  {% if showRisks %}
       <h2 class="govuk-heading-m" data-test="alerts-heading">You must consider the risks of the prisoners involved</h2>
       <p class="govuk-body" data-test="alerts-sub-heading">You are moving a prisoner:</p>
       <ul>

--- a/views/cellMove/moveValidation.njk
+++ b/views/cellMove/moveValidation.njk
@@ -109,7 +109,7 @@ C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.
   {% endif %}
 
 
-  {% if currentOffenderActiveAlerts.length or currentOccupantsActiveAlerts.length %}
+  {% if currentOffenderActiveAlerts.length or currentOccupantsActiveAlerts.length or categoryWarning %}
       <h2 class="govuk-heading-m" data-test="alerts-heading">You must consider the risks of the prisoners involved</h2>
       <p class="govuk-body" data-test="alerts-sub-heading">You are moving a prisoner:</p>
       <ul>


### PR DESCRIPTION
Previously whether the category warning showed up was dependent on there being alerts, the two were wrongly tied together. This decouples the logic and ensures the category warning shows when the offender is cat A and there are other offenders in the cell.