### PR TITLE
NN-2716: Update behaviour for LGB alert

### DIFF
--- a/backend/tests/cellMove/moveValidation.test.js
+++ b/backend/tests/cellMove/moveValidation.test.js
@@ -461,12 +461,6 @@ describe('move validation', () => {
             comment: 'has a large poster on cell wall',
             date: 'Date added: 20 August 2019',
             subTitle: 'The details of Test User&rsquo;s alert are',
-            title: 'who has a Risk to LGB alert into a cell with another prisoner',
-          },
-          {
-            comment: 'has a large poster on cell wall',
-            date: 'Date added: 20 August 2019',
-            subTitle: 'The details of Test User&rsquo;s alert are',
             title: 'who is an E-List prisoner into a cell with another prisoner',
           },
           {


### PR DESCRIPTION
Previously we were showing the LGB alert regardless of the sexualities involved, it was just the wording that changed. This updates it so that we only show the alert if there are non-straight sexualities involved, otherwise do not include the alert in the risks at all.