### PR TITLE
NN-2933: Check assigned living unit exists

### DIFF
--- a/backend/controllers/cellMove/selectCell.js
+++ b/backend/controllers/cellMove/selectCell.js
@@ -98,8 +98,10 @@ const getResidentialLevelNonAssociations = async (res, { elite2Api, nonAssociati
   if (!nonAssociations || !cellId) return []
 
   if (!location || location === 'ALL') {
-    return nonAssociations.nonAssociations.filter(nonAssociation =>
-      nonAssociation.offenderNonAssociation.assignedLivingUnitDescription.includes(agencyId)
+    return nonAssociations.nonAssociations.filter(
+      nonAssociation =>
+        nonAssociation.offenderNonAssociation.assignedLivingUnitDescription &&
+        nonAssociation.offenderNonAssociation.assignedLivingUnitDescription.includes(agencyId)
     )
   }
   // Get the residential unit level prefix for the selected cell by traversing up the
@@ -108,8 +110,10 @@ const getResidentialLevelNonAssociations = async (res, { elite2Api, nonAssociati
   const parentLocationDetail = await elite2Api.getLocation(res.locals, locationDetail.parentLocationId)
   const { locationPrefix } = await elite2Api.getLocation(res.locals, parentLocationDetail.parentLocationId)
 
-  return nonAssociations.nonAssociations.filter(nonAssociation =>
-    nonAssociation.offenderNonAssociation.assignedLivingUnitDescription.includes(locationPrefix)
+  return nonAssociations.nonAssociations.filter(
+    nonAssociation =>
+      nonAssociation.offenderNonAssociation.assignedLivingUnitDescription &&
+      nonAssociation.offenderNonAssociation.assignedLivingUnitDescription.includes(locationPrefix)
   )
 }
 

--- a/backend/tests/cellMove/selectCell.test.js
+++ b/backend/tests/cellMove/selectCell.test.js
@@ -756,5 +756,42 @@ describe('Select a cell', () => {
         })
       )
     })
+
+    it('should set show non association value to false when non association offender does not have assigned living unit', async () => {
+      elite2Api.getNonAssociations = jest.fn().mockResolvedValue({
+        offenderNo: 'G6123VU',
+        firstName: 'JOHN',
+        lastName: 'SAUNDERS',
+        agencyDescription: 'MOORLAND (HMP & YOI)',
+        assignedLivingUnitDescription: 'MDI-1-1-015',
+        nonAssociations: [
+          {
+            reasonCode: 'RIV',
+            reasonDescription: 'Rival Gang',
+            typeCode: 'LAND',
+            typeDescription: 'Do Not Locate on Same Landing',
+            effectiveDate: '2020-06-17T00:00:00',
+            expiryDate: '2020-07-17T00:00:00',
+            comments: 'Gang violence',
+            offenderNonAssociation: {
+              offenderNo: 'A111111',
+              firstName: 'bob1',
+              lastName: 'doe1',
+              reasonCode: 'RIV',
+              reasonDescription: 'Rival Gang',
+              agencyDescription: 'OUTSIDE',
+            },
+          },
+        ],
+      })
+      await controller(req, res)
+
+      expect(res.render).toHaveBeenCalledWith(
+        'cellMove/selectCell.njk',
+        expect.objectContaining({
+          showNonAssociationWarning: false,
+        })
+      )
+    })
   })
 })


### PR DESCRIPTION
Sometimes a non-association's location with be 'OUTSIDE' which means they are no longer relevant to cell move, but also, that they don't have an assigned living unit. This PR handles that case.