### PR TITLE
NN-2964 Update select cell page

### DIFF
--- a/integration-tests/integration/cellMove/selectCell.spec.js
+++ b/integration-tests/integration/cellMove/selectCell.spec.js
@@ -124,7 +124,7 @@ context('A user can select a cell', () => {
           .then($tableRows => {
             cy.get($tableRows)
               .its('length')
-              .should('eq', 10)
+              .should('eq', 9)
 
             const columns = $tableRows.find('td')
 
@@ -215,8 +215,6 @@ context('A user can select a cell', () => {
               relevantAlerts: 'PEEP',
               selectCell: '',
             })
-
-            expect($tableRows.last().get(0).innerText).to.contain('Cell swap\tSelect')
           })
       })
     })
@@ -232,7 +230,7 @@ context('A user can select a cell', () => {
       page.nonAssociationWarning().should('not.be.visible')
     })
 
-    it('should navigate to the confirm cell move page on select c-swap', () => {
+    it('should navigate to the confirm cell move page on Move to cell swap', () => {
       const page = SelectCellPage.goTo(offenderNo, '1')
 
       page
@@ -241,6 +239,22 @@ context('A user can select a cell', () => {
         .then(href => {
           expect(href).to.equal('/prisoner/A12345/cell-move/confirm-cell-move?cellId=C-SWAP')
         })
+    })
+  })
+
+  context('without cell data', () => {
+    const response = []
+
+    beforeEach(() => {
+      cy.task('stubCellsWithCapacity', { cells: response })
+      cy.task('stubCellsWithCapacityByGroupName', { agencyId: 'MDI', groupName: 1, response })
+    })
+
+    it('should load without error and display no results message', () => {
+      const page = SelectCellPage.goTo(offenderNo)
+
+      page.checkStillOnPage()
+      page.noResultsMessage().contains('There are no results for what you have chosen.')
     })
   })
 })

--- a/integration-tests/integration/cellMove/selectCell.spec.js
+++ b/integration-tests/integration/cellMove/selectCell.spec.js
@@ -95,7 +95,7 @@ context('A user can select a cell', () => {
         userDescription: 'LEI-1-1',
       },
       {
-        attributes: [{ code: 'LC', description: 'Listener Cell' }],
+        attributes: [{ code: 'LC', description: 'Listener Cell' }, { description: 'Gated Cell', code: 'GC' }],
         capacity: 3,
         description: 'LEI-1-1',
         id: 1,
@@ -130,7 +130,7 @@ context('A user can select a cell', () => {
 
             assertRow(0, columns, {
               location: 'LEI-1-1',
-              cellType: 'Listener Cell',
+              cellType: 'Gated Cell,\nListener Cell',
               capacity: 3,
               spaces: 1,
               occupier: 'Doe, Bob\nView details\nfor Doe, Bob\nNON-ASSOCIATION',

--- a/integration-tests/pages/cellMove/selectCellPage.js
+++ b/integration-tests/pages/cellMove/selectCellPage.js
@@ -8,6 +8,7 @@ const selectCellPage = () =>
     locationTableHeader: () => cy.get('[data-test="location-table-header"]').find('button'),
     nonAssociationWarning: () => cy.get('#non-association-warning'),
     selectCswapLink: () => cy.get('[data-test="select-cswap-link"]'),
+    noResultsMessage: () => cy.get('[data-test="no-results-message"]'),
   })
 
 export default {

--- a/views/cellMove/selectCell.njk
+++ b/views/cellMove/selectCell.njk
@@ -14,7 +14,7 @@
 
   {% if index === 1 %}
     <td class="{{ cellClass }}">{{ cell.description }}</th>
-    <td class="{{ cellClass }}">{{ cell.type | join('<br>', 'description') | safe if cell.type.length else '--' }}</td>
+    <td class="{{ cellClass }}">{{ cell.type | join(',<br>', 'description') | safe if cell.type.length else 'Nothing entered' }}</td>
     <td class="{{ cellClass }}">{{ cell.capacity }}</td>
     <td class="{{ cellClass }}">{{ cell.spaces }}</td>
   {% else %}
@@ -147,52 +147,60 @@
     </div>
   </div>
 
-  {% if showNonAssociationWarning %}
-    {{ govukWarningText({
-      attributes: {
-        id: 'non-association-warning'
-      },
-      text: breadcrumbPrisonerName + " has a non-association with a prisoner in this location.",
-      iconFallbackText: "Warning"
-    }) }}
-  {% endif %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {% if showNonAssociationWarning %}
+        {{ govukWarningText({
+          attributes: {
+            id: 'non-association-warning'
+          },
+          text: breadcrumbPrisonerName + " has a non-association with a prisoner in this location.",
+          iconFallbackText: "Warning"
+        }) }}
+      {% endif %}
+    </div>
 
-  <table class="govuk-table govuk-table--with-child-rows" data-test="cell-results-table">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header" data-test="location-table-header">Location</th>
-        <th scope="col" class="govuk-table__header">Cell type</th>
-        <th scope="col" class="govuk-table__header">Capacity</th>
-        <th scope="col" class="govuk-table__header">Spaces</th>
-        <th scope="col" class="govuk-table__header">Occupier</th>
+    <div class="{{ 'govuk-grid-column-one-third' if showNonAssociationWarning else 'govuk-grid-column-full' }}">
+      <p class="govuk-body pull-right govuk-!-margin-top-2">
+        <a data-test="select-cswap-link" href="{{ '/prisoner/' + offenderNo + '/cell-move/confirm-cell-move?cellId=C-SWAP' }}" class="govuk-link">Move to cell swap</a>
+      </p>
+    </div>
+  </div>
 
-        <th scope="col" class="govuk-table__header">CSRA</th>
-        <th scope="col" class="govuk-table__header">Relevant alerts</th>
-        <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Select cell</span></th>
-      </tr>
-    </thead>
-    <tbody class="govuk-table__body">
-      {% for cell in cells %}
-        {% if cell.occupants.length > 0 %}
-             {% for occupier in cell.occupants %}
-               <tr class="govuk-table__row">
-                 {{ makeRow(cell, loop.index, cell.occupants.length === loop.index, occupier) }}
-               </tr>
-              {% endfor %}
-        {% else %}
+  {% if cells %}
+    <table class="govuk-table govuk-table--with-child-rows" data-test="cell-results-table">
+      <thead class="govuk-table__head">
         <tr class="govuk-table__row">
-          {{ makeRow(cell, 1, true, null) }}
+          <th scope="col" class="govuk-table__header" data-test="location-table-header">Location</th>
+          <th scope="col" class="govuk-table__header">Cell type</th>
+          <th scope="col" class="govuk-table__header">Capacity</th>
+          <th scope="col" class="govuk-table__header">Spaces</th>
+          <th scope="col" class="govuk-table__header">Occupier</th>
+
+          <th scope="col" class="govuk-table__header">CSRA</th>
+          <th scope="col" class="govuk-table__header">Relevant alerts</th>
+          <th scope="col" class="govuk-table__header"><span class="govuk-visually-hidden">Select cell</span></th>
         </tr>
-        {% endif%}
-      {% endfor %}
-    </tbody>
-    <tfoot>
-      <tr class="govuk-table__row">
-        <td class="govuk-table__cell" colspan="7">Cell swap</td>
-        <td class="govuk-table__cell"><a data-test="select-cswap-link" href="{{ '/prisoner/' + offenderNo + '/cell-move/confirm-cell-move?cellId=C-SWAP' }}" class="govuk-link">Select</a></td>
-      </tr>
-    </tfoot>
-  </table>
+      </thead>
+      <tbody class="govuk-table__body">
+        {% for cell in cells %}
+          {% if cell.occupants.length > 0 %}
+              {% for occupier in cell.occupants %}
+                <tr class="govuk-table__row">
+                  {{ makeRow(cell, loop.index, cell.occupants.length === loop.index, occupier) }}
+                </tr>
+                {% endfor %}
+          {% else %}
+          <tr class="govuk-table__row">
+            {{ makeRow(cell, 1, true, null) }}
+          </tr>
+          {% endif%}
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p class="govuk-body" data-test="no-results-message">There are no results for what you have chosen.</p>
+  {% endif %}
 
 {% endblock %}
 


### PR DESCRIPTION
Some tweaks to the Select cell page.
- Show message when there are no results
- Move cell swap link to top right (formerly bottom of table)
![image](https://user-images.githubusercontent.com/1067537/94807022-dffa0d00-03e6-11eb-8f02-2082c6fbf365.png)

- Seperate cell types by comma and new line:
![image](https://user-images.githubusercontent.com/1067537/94807492-a83f9500-03e7-11eb-8be5-14b7adc14cd5.png)

