### PR TITLE
NN-2994: Reset stubbing only once per spec

### DIFF
--- a/integration-tests/integration/adjudicationHistory/adjudicationHistory.spec.js
+++ b/integration-tests/integration/adjudicationHistory/adjudicationHistory.spec.js
@@ -48,13 +48,12 @@ const adjudicationResponse = {
 context('A user can confirm the cell move', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubBookingDetails', {
       firstName: 'Bob',
       lastName: 'Doe',

--- a/integration-tests/integration/alerts/createAlert.spec.js
+++ b/integration-tests/integration/alerts/createAlert.spec.js
@@ -7,13 +7,12 @@ const NotFoundPage = require('../../pages/notFound')
 context('A user can add an appointment', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     const offenderNo = 'A12345'
     cy.task('stubOffenderFullDetails', offenderFullDetails)
     cy.task('stubAlertTypes')

--- a/integration-tests/integration/alerts/editAlert.spec.js
+++ b/integration-tests/integration/alerts/editAlert.spec.js
@@ -10,13 +10,12 @@ const alertId = 1
 context('A user can add an appointment', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubOffenderBasicDetails', offenderBasicDetails)
     cy.task('stubOffenderFullDetails', offenderFullDetails)
     cy.task('stubAlertTypes')

--- a/integration-tests/integration/appointments/addAppointment.spec.js
+++ b/integration-tests/integration/appointments/addAppointment.spec.js
@@ -3,7 +3,6 @@ const moment = require('moment')
 const offenderBasicDetails = require('../../mockApis/responses/offenderBasicDetails.json')
 const AddAppointmentPage = require('../../pages/appointments/addAppointmentPage')
 const ConfirmSingleAppointmentPage = require('../../pages/appointments/confirmSingleAppointmentPage')
-const ConfirmRecurringAppointmentPage = require('../../pages/appointments/confirmRecurringAppointmentPage')
 const PrePostAppointmentsPage = require('../../pages/appointments/prePostAppointmentsPage')
 const OtherCourtPage = require('../../pages/appointments/otherCourtPage')
 const ConfirmVideoLinkPrisonPage = require('../../pages/appointments/confirmVideoLinkPrisonPage')
@@ -11,13 +10,12 @@ const ConfirmVideoLinkPrisonPage = require('../../pages/appointments/confirmVide
 context('A user can add an appointment', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'WWI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     const offenderNo = 'A12345'
     cy.task('stubOffenderBasicDetails', offenderBasicDetails)
     cy.task('stubAppointmentTypes', [

--- a/integration-tests/integration/appointments/addBulkAppointments.spec.js
+++ b/integration-tests/integration/appointments/addBulkAppointments.spec.js
@@ -10,13 +10,12 @@ const BulkAppointmentUploadCSVPage = require('../../pages/appointments/bulkAppoi
 context('A user can add a bulk appointment', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     const offenderNo = 'A12345'
     cy.task('stubAppointmentTypes', [
       { code: 'ACTI', description: 'Activities' },

--- a/integration-tests/integration/appointments/addCourtAppointmentPrison.spec.js
+++ b/integration-tests/integration/appointments/addCourtAppointmentPrison.spec.js
@@ -10,13 +10,12 @@ const SelectCourtAppointmentRoomsPage = require('../../pages/appointments/select
 context('A user can add a video link', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     const offenderNo = 'A12345'
     cy.task('stubOffenderBasicDetails', offenderBasicDetails)
     cy.task('stubAppointmentTypes', [

--- a/integration-tests/integration/appointments/requestCourtBooking.spec.js
+++ b/integration-tests/integration/appointments/requestCourtBooking.spec.js
@@ -7,13 +7,12 @@ const RequestCourtBookingConfirmationPage = require('../../pages/appointments/re
 context('A user can request a booking', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'WWI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubCourts')
     cy.task('stubAgencies', [{ agencyId: 'WWI', description: 'HMP Wandsworth' }])
     cy.task('stubUserEmail', 'ITAG_USER')

--- a/integration-tests/integration/appointments/viewAppointments.spec.js
+++ b/integration-tests/integration/appointments/viewAppointments.spec.js
@@ -3,13 +3,12 @@ const ViewAppointmentsPage = require('../../pages/appointments/viewAppointmentsP
 context('A user can view list of appointments', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubAppointmentTypes', [
       { code: 'ACTI', description: 'Activities' },
       { code: 'VLB', description: 'Video Link Booking' },

--- a/integration-tests/integration/attendance/attendanceStatsPage.spec.js
+++ b/integration-tests/integration/attendance/attendanceStatsPage.spec.js
@@ -7,14 +7,13 @@ const agencyId = 'WWI'
 context('A user can view attendance changes', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'WWI' })
     cy.login()
   })
 
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubUserMeRoles')
     cy.task('stubUserMe')
     cy.task('stubUserCaseLoads')

--- a/integration-tests/integration/caseNotes/createCaseNote.spec.js
+++ b/integration-tests/integration/caseNotes/createCaseNote.spec.js
@@ -8,13 +8,12 @@ const PrisonerCaseNotePage = require('../../pages/prisonerProfile/caseNotePage')
 context('A user can add a case note', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubOffenderBasicDetails', offenderBasicDetails)
     const offenderNo = 'A12345'
     cy.task('stubCaseNoteTypesForUser')

--- a/integration-tests/integration/cellMove/cellMoveConfirmation.spec.js
+++ b/integration-tests/integration/cellMove/cellMoveConfirmation.spec.js
@@ -6,13 +6,12 @@ const cellId = 1
 context('A user get confirmation of a cell move', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubBookingDetails', {
       firstName: 'Bob',
       lastName: 'Doe',

--- a/integration-tests/integration/cellMove/cellNotAvailable.spec.js
+++ b/integration-tests/integration/cellMove/cellNotAvailable.spec.js
@@ -5,13 +5,12 @@ const offenderNo = 'A12345'
 context('A user is presented with a cell no longer available error page', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubBookingDetails', {
       firstName: 'Bob',
       lastName: 'Doe',

--- a/integration-tests/integration/cellMove/confirmCellMove.spec.js
+++ b/integration-tests/integration/cellMove/confirmCellMove.spec.js
@@ -7,13 +7,12 @@ const offenderNo = 'A1234A'
 context('A user can confirm the cell move', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubBookingDetails', {
       firstName: 'Bob',
       lastName: 'Doe',

--- a/integration-tests/integration/cellMove/cswapConfirmation.spec.js
+++ b/integration-tests/integration/cellMove/cswapConfirmation.spec.js
@@ -1,18 +1,16 @@
 const cswapConfirmationPage = require('../../pages/cellMove/cswapConfirmationPage')
 
 const offenderNo = 'A1234A'
-const cellId = 1
 
 context('A user get confirmation of a cell move', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubBookingDetails', {
       firstName: 'Bob',
       lastName: 'Doe',

--- a/integration-tests/integration/cellMove/moveValidation.spec.js
+++ b/integration-tests/integration/cellMove/moveValidation.spec.js
@@ -155,13 +155,12 @@ context('A user can see conflicts in cell', () => {
   }
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubInmatesAtLocation', {
       inmates: [{ offenderNo: 'A12345', firstName: 'Bob', lastName: 'Doe', assignedLivingUnitId: 1 }],
     })

--- a/integration-tests/integration/cellMove/selectCell.spec.js
+++ b/integration-tests/integration/cellMove/selectCell.spec.js
@@ -22,13 +22,12 @@ context('A user can select a cell', () => {
   }
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubOffenderFullDetails', offenderFullDetails)
     cy.task('stubGroups', { id: 'MDI' })
     cy.task('stubCellAttributes')

--- a/integration-tests/integration/cellMove/selectLocation.spec.js
+++ b/integration-tests/integration/cellMove/selectLocation.spec.js
@@ -8,13 +8,12 @@ const offenderNo = 'A12345'
 context('A user can select a cell', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubOffenderFullDetails', offenderFullDetails)
     cy.task('stubBookingNonAssociations', {})
     cy.task('stubGroups', { id: 'MDI' })

--- a/integration-tests/integration/cellMove/viewCellSharingRiskAssessmentDetails.spec.js
+++ b/integration-tests/integration/cellMove/viewCellSharingRiskAssessmentDetails.spec.js
@@ -6,13 +6,12 @@ const offenderNo = 'A12345'
 context('A user can view non associations', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubOffenderFullDetails', offenderFullDetails)
     cy.task('stubCsraAssessments', {
       offenderNumbers: [offenderNo],

--- a/integration-tests/integration/cellMove/viewNonAssociations.spec.js
+++ b/integration-tests/integration/cellMove/viewNonAssociations.spec.js
@@ -11,13 +11,12 @@ const tomorrow = moment()
 context('A user can view non associations', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubOffenderBasicDetails', offenderBasicDetails)
     cy.task('stubBookingNonAssociations', {
       offenderNo: 'A12345',

--- a/integration-tests/integration/cellMove/viewOffenderDetails.spec.js
+++ b/integration-tests/integration/cellMove/viewOffenderDetails.spec.js
@@ -6,13 +6,12 @@ const offenderNo = 'A12345'
 context('A user can view non associations', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubOffenderFullDetails', {
       ...offenderFullDetails,
       age: 29,

--- a/integration-tests/integration/dataCompliance/retentionReasons.spec.js
+++ b/integration-tests/integration/dataCompliance/retentionReasons.spec.js
@@ -1,21 +1,19 @@
 const offenderBasicDetails = require('../../mockApis/responses/offenderBasicDetails.json')
 const offenderFullDetails = require('../../mockApis/responses/offenderFullDetails.json')
 const RetentionReasonsPage = require('../../pages/dataCompliance/retentionReasonsPage')
-const PrisonerQuickLookPage = require('../../pages/prisonerProfile/prisonerQuickLookPage')
 
 const offenderNo = 'A12345'
 
 context('Retention reasons', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
 
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubGetOffenderRetentionReasons')
     cy.task('stubNoExistingOffenderRecord', { offenderNo })
     cy.task('stubAgencyDetails', { agencyId: 'MDI', details: { description: 'Moorland' } })

--- a/integration-tests/integration/establishmentRollCount/inReception.spec.js
+++ b/integration-tests/integration/establishmentRollCount/inReception.spec.js
@@ -1,13 +1,12 @@
 context('A user can see the list of offenders in reception', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubClientCredentialsRequest')
     cy.task('stubIepSummaryForBookingIds')
     cy.task('stubSystemAlerts')

--- a/integration-tests/integration/prisonerProfile/prisonerAlertsPage.spec.js
+++ b/integration-tests/integration/prisonerProfile/prisonerAlertsPage.spec.js
@@ -47,7 +47,7 @@ context('A user can view alerts for a prisoner', () => {
 
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
@@ -56,7 +56,6 @@ context('A user can view alerts for a prisoner', () => {
     beforeEach(() => {
       // Maintain session between the two tests.
       Cypress.Cookies.preserveOnce('hmpps-session-dev')
-      cy.task('resetAndStubTokenVerification')
       const iepSummary = {}
       const caseNoteSummary = {}
       cy.task('stubPrisonerProfileHeaderData', {
@@ -121,7 +120,6 @@ context('A user can view alerts for a prisoner', () => {
     beforeEach(() => {
       // Maintain session between the two tests.
       Cypress.Cookies.preserveOnce('hmpps-session-dev')
-      cy.task('resetAndStubTokenVerification')
       const iepSummary = {}
       const caseNoteSummary = {}
       cy.task('stubPrisonerProfileHeaderData', {

--- a/integration-tests/integration/prisonerProfile/prisonerPersonal.spec.js
+++ b/integration-tests/integration/prisonerProfile/prisonerPersonal.spec.js
@@ -142,14 +142,13 @@ context('Prisoner personal', () => {
 
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
 
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubPathFinderOffenderDetails', null)
     cy.task('stubClientCredentialsRequest')
   })

--- a/integration-tests/integration/prisonerProfile/prisonerProfessionalContacts.spec.js
+++ b/integration-tests/integration/prisonerProfile/prisonerProfessionalContacts.spec.js
@@ -97,14 +97,13 @@ const otherContacts = [
 context('Prisoner professional contacts', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
 
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubPathFinderOffenderDetails', null)
     cy.task('stubClientCredentialsRequest')
   })

--- a/integration-tests/integration/prisonerProfile/prisonerSentenceAndRelease.spec.js
+++ b/integration-tests/integration/prisonerProfile/prisonerSentenceAndRelease.spec.js
@@ -5,7 +5,7 @@ const offenderFullDetails = require('../../mockApis/responses/offenderFullDetail
 context('Prisoner sentence and release', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
@@ -13,7 +13,6 @@ context('Prisoner sentence and release', () => {
   beforeEach(() => {
     // Maintain session between the two tests.
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubPrisonerProfileHeaderData', {
       offenderBasicDetails,
       offenderFullDetails,

--- a/integration-tests/integration/search/prisonerSearch.spec.js
+++ b/integration-tests/integration/search/prisonerSearch.spec.js
@@ -34,14 +34,13 @@ context('Prisoner search', () => {
 
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLogin', { username: 'ITAG_USER', caseload: 'MDI' })
     cy.login()
   })
 
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
   })
 
   context('When there are no search values', () => {

--- a/integration-tests/integration/videolink/courtVideoLinkBookingsPage.spec.js
+++ b/integration-tests/integration/videolink/courtVideoLinkBookingsPage.spec.js
@@ -3,14 +3,13 @@ const CourtVideoLinkBookingsPage = require('../../pages/videolink/courtVideoBook
 context('A user can view the video link home page', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLoginCourt')
     cy.login()
   })
 
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubCourts')
     cy.task('stubAppointmentsGet', [
       {

--- a/integration-tests/integration/videolink/prisonerSearch.spec.js
+++ b/integration-tests/integration/videolink/prisonerSearch.spec.js
@@ -1,14 +1,13 @@
 context('A user can search for an offender', () => {
   before(() => {
     cy.clearCookies()
-    cy.task('reset')
+    cy.task('resetAndStubTokenVerification')
     cy.task('stubLoginCourt')
     cy.login()
   })
 
   beforeEach(() => {
     Cypress.Cookies.preserveOnce('hmpps-session-dev')
-    cy.task('resetAndStubTokenVerification')
     cy.task('stubUserMeRoles', [{ roleCode: 'VIDEO_LINK_COURT_USER' }])
     cy.task('stubUserMe')
     cy.task('stubUserCaseLoads')


### PR DESCRIPTION
We were calling the reset stubs task multiple times in some specs in close succession which contributed to some stubs not being found on login.