### PR TITLE
NN-3033 Fix from and to dates on location history location titles

### DIFF
--- a/backend/controllers/prisonerProfile/prisonerCellHistory.js
+++ b/backend/controllers/prisonerProfile/prisonerCellHistory.js
@@ -72,8 +72,8 @@ module.exports = ({ oauthApi, prisonApi, logError, page = 0 }) => async (req, re
     return res.render('prisonerProfile/prisonerCellHistory.njk', {
       cellHistoryGroupedByAgency: hasLength(cellData)
         ? Object.entries(groupBy(cellData, 'establishment')).map(([key, value]) => {
-            const fromDateString = formatTimestampToDate(value[0].assignmentDateTime)
-            const toDateString = formatTimestampToDate(value.slice(-1)[0].assignmentEndDateTime)
+            const fromDateString = formatTimestampToDate(value.slice(-1)[0].assignmentDateTime)
+            const toDateString = formatTimestampToDate(value[0].assignmentEndDateTime)
 
             return {
               name: key,

--- a/backend/tests/prisonerCellHistory.test.js
+++ b/backend/tests/prisonerCellHistory.test.js
@@ -81,7 +81,7 @@ describe('Prisoner cell history', () => {
 
     controller = prisonerCellHistory({ oauthApi, prisonApi, logError })
 
-    jest.spyOn(Date, 'now').mockImplementation(() => 1603988100000) // Friday, 29 Oct 2020 16:15 UTC (avoid BST)20_10_29_16_06
+    jest.spyOn(Date, 'now').mockImplementation(() => 1603988100000) // Friday, 29 Oct 2020 16:15 UTC (avoid BST)
   })
 
   afterEach(() => {
@@ -97,6 +97,7 @@ describe('Prisoner cell history', () => {
     expect(prisonApi.getInmatesAtLocation).toHaveBeenCalledWith(res.locals, 1, {})
     expect(prisonApi.getStaffDetails.mock.calls.length).toBe(3)
     expect(prisonApi.getStaffDetails).toHaveBeenCalledWith(res.locals, 'STAFF_2')
+    expect(prisonApi.getStaffDetails).toHaveBeenCalledWith(res.locals, 'STAFF_3')
   })
 
   describe('cell history for offender', () => {

--- a/backend/tests/prisonerCellHistory.test.js
+++ b/backend/tests/prisonerCellHistory.test.js
@@ -1,4 +1,3 @@
-const moment = require('moment')
 const prisonerCellHistory = require('../controllers/prisonerProfile/prisonerCellHistory')
 
 describe('Prisoner cell history', () => {
@@ -29,28 +28,6 @@ describe('Prisoner cell history', () => {
     prisonApi.getOffenderCellHistory = jest.fn().mockResolvedValue({
       content: [
         {
-          agencyId: 'MDI',
-          assignmentDate: '2020-03-01',
-          assignmentDateTime: '2020-03-01T12:48:33.375Z', // Avoid BST
-          assignmentReason: 'ADM',
-          bookingId,
-          description: 'MDI-1-02',
-          livingUnitId: 1,
-          movementMadeBy: 'STAFF_1',
-        },
-        {
-          agencyId: 'MDI',
-          assignmentDate: '2020-01-01',
-          assignmentDateTime: '2020-01-01T12:48:33.375Z',
-          assignmentEndDate: '2020-02-01',
-          assignmentEndDateTime: '2020-02-01T12:48:33.375Z',
-          assignmentReason: 'ADM',
-          bookingId,
-          description: 'MDI-1-02',
-          livingUnitId: 2,
-          movementMadeBy: 'STAFF_3',
-        },
-        {
           agencyId: 'RNI',
           assignmentDate: '2020-02-01',
           assignmentDateTime: '2020-02-01T12:48:33.375Z',
@@ -62,6 +39,40 @@ describe('Prisoner cell history', () => {
           livingUnitId: 3,
           movementMadeBy: 'STAFF_2',
         },
+        {
+          agencyId: 'MDI',
+          assignmentDate: '2020-05-01',
+          assignmentDateTime: '2020-05-01T12:48:33.375Z', // Avoid BST
+          assignmentReason: 'ADM',
+          bookingId,
+          description: 'MDI-1-02',
+          livingUnitId: 1,
+          movementMadeBy: 'STAFF_1',
+        },
+        {
+          agencyId: 'MDI',
+          assignmentDate: '2020-03-01',
+          assignmentDateTime: '2020-03-01T12:48:33.375Z',
+          assignmentEndDate: '2020-04-01',
+          assignmentEndDateTime: '2020-04-01T12:48:33.375Z',
+          assignmentReason: 'ADM',
+          bookingId,
+          description: 'MDI-1-02',
+          livingUnitId: 2,
+          movementMadeBy: 'STAFF_3',
+        },
+        {
+          agencyId: 'MDI',
+          assignmentDate: '2020-04-01',
+          assignmentDateTime: '2020-04-01T12:48:33.375Z',
+          assignmentEndDate: '2020-05-01',
+          assignmentEndDateTime: '2020-05-01T12:48:33.375Z',
+          assignmentReason: 'ADM',
+          bookingId,
+          description: 'MDI-1-03',
+          livingUnitId: 2,
+          movementMadeBy: 'STAFF_3',
+        },
       ],
     })
     prisonApi.getAgencyDetails = jest.fn().mockResolvedValue([])
@@ -69,6 +80,12 @@ describe('Prisoner cell history', () => {
     prisonApi.getStaffDetails = jest.fn().mockResolvedValue({ bookingId, firstName: 'John', lastName: 'Smith' })
 
     controller = prisonerCellHistory({ oauthApi, prisonApi, logError })
+
+    jest.spyOn(Date, 'now').mockImplementation(() => 1603988100000) // Friday, 29 Oct 2020 16:15 UTC (avoid BST)20_10_29_16_06
+  })
+
+  afterEach(() => {
+    Date.now.mockRestore()
   })
 
   it('should make the expected API calls', async () => {
@@ -78,7 +95,7 @@ describe('Prisoner cell history', () => {
     expect(prisonApi.getOffenderCellHistory).toHaveBeenCalledWith(res.locals, bookingId, { page: 0, size: 10000 })
     expect(prisonApi.getAgencyDetails.mock.calls.length).toBe(2)
     expect(prisonApi.getInmatesAtLocation).toHaveBeenCalledWith(res.locals, 1, {})
-    expect(prisonApi.getStaffDetails.mock.calls.length).toBe(2)
+    expect(prisonApi.getStaffDetails.mock.calls.length).toBe(3)
     expect(prisonApi.getStaffDetails).toHaveBeenCalledWith(res.locals, 'STAFF_2')
   })
 
@@ -96,64 +113,71 @@ describe('Prisoner cell history', () => {
     it('sends the right data to the template', async () => {
       await controller(req, res)
 
-      expect(res.render).toHaveBeenCalledWith(
-        'prisonerProfile/prisonerCellHistory.njk',
-        expect.objectContaining({
-          cellHistoryGroupedByAgency: [
-            {
-              name: 'Ranby',
-              datePeriod: 'from 01/02/2020 to 01/03/2020',
-              cellHistory: [
-                {
-                  agencyId: 'RNI',
-                  assignmentDateTime: '2020-02-01T12:48:33',
-                  assignmentEndDateTime: '2020-03-01T12:48:33',
-                  establishment: 'Ranby',
-                  livingUnitId: 3,
-                  location: '1-03',
-                  movedBy: 'John Smith',
-                  movedIn: '01/02/2020 - 12:48',
-                  movedOut: '01/03/2020 - 12:48',
-                },
-              ],
-            },
-            {
-              name: 'Moorland',
-              datePeriod: 'from 01/01/2020 to 01/02/2020',
-              cellHistory: [
-                {
-                  agencyId: 'MDI',
-                  assignmentDateTime: '2020-01-01T12:48:33',
-                  assignmentEndDateTime: '2020-02-01T12:48:33',
-                  establishment: 'Moorland',
-                  livingUnitId: 2,
-                  location: '1-02',
-                  movedBy: 'John Smith',
-                  movedIn: '01/01/2020 - 12:48',
-                  movedOut: '01/02/2020 - 12:48',
-                },
-              ],
-            },
-          ],
-          occupants: [
-            {
-              name: 'Offender, Another',
-              profileUrl: '/prisoner/B12345',
-            },
-          ],
-          currentLocation: {
-            agencyId: 'MDI',
-            assignmentDateTime: '2020-03-01T12:48:33',
-            assignmentEndDateTime: moment().format('YYYY-MM-DDTHH:mm:ss'),
-            establishment: 'Moorland',
-            livingUnitId: 1,
-            location: '1-02',
-            movedIn: '01/03/2020 - 12:48',
+      expect(res.render).toHaveBeenCalledWith('prisonerProfile/prisonerCellHistory.njk', {
+        breadcrumbPrisonerName: 'Smith, John',
+        canViewCellMoveButton: false,
+        cellHistoryGroupedByAgency: [
+          {
+            name: 'Moorland',
+            datePeriod: 'from 01/03/2020 to 01/05/2020',
+            cellHistory: [
+              {
+                agencyId: 'MDI',
+                assignmentDateTime: '2020-04-01T12:48:33',
+                assignmentEndDateTime: '2020-05-01T12:48:33',
+                establishment: 'Moorland',
+                livingUnitId: 2,
+                location: '1-03',
+                movedBy: 'John Smith',
+                movedIn: '01/04/2020 - 12:48',
+                movedOut: '01/05/2020 - 12:48',
+              },
+              {
+                agencyId: 'MDI',
+                assignmentDateTime: '2020-03-01T12:48:33',
+                assignmentEndDateTime: '2020-04-01T12:48:33',
+                establishment: 'Moorland',
+                livingUnitId: 2,
+                location: '1-02',
+                movedBy: 'John Smith',
+                movedIn: '01/03/2020 - 12:48',
+                movedOut: '01/04/2020 - 12:48',
+              },
+            ],
           },
-          canViewCellMoveButton: false,
-          prisonerName: 'John Smith',
-        })
-      )
+          {
+            name: 'Ranby',
+            datePeriod: 'from 01/02/2020 to 01/03/2020',
+            cellHistory: [
+              {
+                agencyId: 'RNI',
+                assignmentDateTime: '2020-02-01T12:48:33',
+                assignmentEndDateTime: '2020-03-01T12:48:33',
+                establishment: 'Ranby',
+                livingUnitId: 3,
+                location: '1-03',
+                movedBy: 'John Smith',
+                movedIn: '01/02/2020 - 12:48',
+                movedOut: '01/03/2020 - 12:48',
+              },
+            ],
+          },
+        ],
+        changeCellLink: '/prisoner/ABC123/cell-move/select-location',
+        currentLocation: {
+          agencyId: 'MDI',
+          assignmentDateTime: '2020-05-01T12:48:33',
+          assignmentEndDateTime: '2020-10-29T16:15:00',
+          establishment: 'Moorland',
+          livingUnitId: 1,
+          location: '1-02',
+          movedIn: '01/05/2020 - 12:48',
+        },
+        dpsUrl: 'http://localhost:3000/',
+        occupants: [{ name: 'Offender, Another', profileUrl: '/prisoner/B12345' }],
+        prisonerName: 'John Smith',
+        profileUrl: '/prisoner/ABC123',
+      })
     })
 
     it('sets the cell move correctly if role exists', async () => {

--- a/integration-tests/integration/prisonerProfile/prisonerCellHistory.spec.js
+++ b/integration-tests/integration/prisonerProfile/prisonerCellHistory.spec.js
@@ -26,8 +26,8 @@ context('Prisoner cell history', () => {
           content: [
             {
               agencyId: 'MDI',
-              assignmentDate: '2020-09-01',
-              assignmentDateTime: '2020-09-01T12:48:33.375Z',
+              assignmentDate: '2020-05-01',
+              assignmentDateTime: '2020-05-01T12:48:33.375Z',
               assignmentReason: 'ADM',
               bookingId: 123,
               description: 'MDI-1-02',
@@ -36,26 +36,26 @@ context('Prisoner cell history', () => {
             },
             {
               agencyId: 'MDI',
-              assignmentDate: '2020-08-01',
-              assignmentDateTime: '2020-08-01T12:48:33.375Z',
-              assignmentEndDate: '2020-09-01',
-              assignmentEndDateTime: '2020-09-01T12:48:33.375Z',
+              assignmentDate: '2020-03-01',
+              assignmentDateTime: '2020-03-01T12:48:33.375Z',
+              assignmentEndDate: '2020-04-01',
+              assignmentEndDateTime: '2020-04-01T12:48:33.375Z',
               assignmentReason: 'ADM',
               bookingId: 123,
-              description: 'MDI-1-03',
-              livingUnitId: 3,
+              description: 'MDI-RECP',
+              livingUnitId: 2,
               movementMadeBy: 'STAFF_2',
             },
             {
               agencyId: 'MDI',
-              assignmentDate: '2020-08-01',
-              assignmentDateTime: '2020-08-01T10:48:33.375Z',
-              assignmentEndDate: '2020-09-01',
-              assignmentEndDateTime: '2020-09-01T11:48:33.375Z',
+              assignmentDate: '2020-04-01',
+              assignmentDateTime: '2020-04-01T12:48:33.375Z',
+              assignmentEndDate: '2020-05-01',
+              assignmentEndDateTime: '2020-05-01T12:48:33.375Z',
               assignmentReason: 'ADM',
               bookingId: 123,
-              description: 'MDI-RECP',
-              livingUnitId: 4,
+              description: 'MDI-1-03',
+              livingUnitId: 3,
               movementMadeBy: 'STAFF_1',
             },
           ],
@@ -63,7 +63,8 @@ context('Prisoner cell history', () => {
       })
       cy.task('stubStaff', { staffId: 'STAFF_1', details: { firstName: 'Staff', lastName: 'One' } })
       cy.task('stubStaff', { staffId: 'STAFF_2', details: { firstName: 'Staff', lastName: 'Two' } })
-      cy.task('stubStaff', { staffId: 'STAFF_2', details: { firstName: 'Staff', lastName: 'Two' } })
+      cy.task('stubStaff', { staffId: 'STAFF_3', details: { firstName: 'Staff', lastName: 'Two' } })
+      cy.task('stubStaff', { staffId: 'STAFF_3', details: { firstName: 'Staff', lastName: 'Two' } })
     })
 
     it('should load the data correcly when one other occupant', () => {
@@ -79,11 +80,11 @@ context('Prisoner cell history', () => {
         .should('have.attr', 'href')
         .and(
           'include',
-          `/location-history?fromDate=2020-09-01T12:48:33&toDate=${moment().format(
+          `/location-history?fromDate=2020-05-01T12:48:33&toDate=${moment().format(
             'YYYY-MM-DDTHH:mm:ss'
           )}&locationId=1&agencyId=MDI`
         )
-      prisonerCellHistoryPage.agencyHeading().contains('Moorland from 01/08/2020 to 01/09/2020')
+      prisonerCellHistoryPage.agencyHeading().contains('Moorland from 01/03/2020 to 01/05/2020')
 
       prisonerCellHistoryPage.results().then($table => {
         cy.get($table)
@@ -94,21 +95,21 @@ context('Prisoner cell history', () => {
               .should('eq', 10) // 2 rows with 5 cells
 
             expect($tableCells.get(0)).to.contain('1-03')
-            expect($tableCells.get(1)).to.contain(moment('2020-08-01T12:48:33.375Z').format('DD/MM/YYYY - HH:mm'))
-            expect($tableCells.get(2)).to.contain(moment('2020-09-01T12:48:33.375Z').format('DD/MM/YYYY - HH:mm'))
-            expect($tableCells.get(3)).to.contain('Staff Two')
+            expect($tableCells.get(1)).to.contain(moment('2020-04-01T12:48:33.375Z').format('DD/MM/YYYY - HH:mm'))
+            expect($tableCells.get(2)).to.contain(moment('2020-05-01T12:48:33.375Z').format('DD/MM/YYYY - HH:mm'))
+            expect($tableCells.get(3)).to.contain('Staff One')
             cy.get($tableCells.get(4))
               .find('a')
               .should('contain.text', 'View details for location 1-03')
               .should('have.attr', 'href')
               .and(
                 'include',
-                '/location-history?fromDate=2020-08-01T12:48:33&toDate=2020-09-01T12:48:33&locationId=3&agencyId=MDI'
+                '/location-history?fromDate=2020-04-01T12:48:33&toDate=2020-05-01T12:48:33&locationId=3&agencyId=MDI'
               )
             expect($tableCells.get(5)).to.contain('Reception')
-            expect($tableCells.get(6)).to.contain(moment('2020-08-01T10:48:33.375Z').format('DD/MM/YYYY - HH:mm'))
-            expect($tableCells.get(7)).to.contain(moment('2020-09-01T11:48:33.375Z').format('DD/MM/YYYY - HH:mm'))
-            expect($tableCells.get(8)).to.contain('Staff One')
+            expect($tableCells.get(6)).to.contain(moment('2020-03-01T12:48:33.375Z').format('DD/MM/YYYY - HH:mm'))
+            expect($tableCells.get(7)).to.contain(moment('2020-04-01T12:48:33.375Z').format('DD/MM/YYYY - HH:mm'))
+            expect($tableCells.get(8)).to.contain('Staff Two')
             expect($tableCells.get(9)).to.contain('')
           })
       })

--- a/integration-tests/integration/prisonerProfile/prisonerCellHistory.spec.js
+++ b/integration-tests/integration/prisonerProfile/prisonerCellHistory.spec.js
@@ -63,8 +63,6 @@ context('Prisoner cell history', () => {
       })
       cy.task('stubStaff', { staffId: 'STAFF_1', details: { firstName: 'Staff', lastName: 'One' } })
       cy.task('stubStaff', { staffId: 'STAFF_2', details: { firstName: 'Staff', lastName: 'Two' } })
-      cy.task('stubStaff', { staffId: 'STAFF_3', details: { firstName: 'Staff', lastName: 'Two' } })
-      cy.task('stubStaff', { staffId: 'STAFF_3', details: { firstName: 'Staff', lastName: 'Two' } })
     })
 
     it('should load the data correcly when one other occupant', () => {


### PR DESCRIPTION
Cell movements are pre sorted in descending order before grouping, so the `fromDateString` and `toDateString` were the wrong way round.  Tests only had 1 record before so passed regardless. 😳 🙈 

Dates now correct as shown in screenshot below:
**From =** earliest move in date
**To =** latest move out date
![image](https://user-images.githubusercontent.com/1067537/99569543-ab5b0880-29c8-11eb-8f7c-6245282942b0.png)
