### PR TITLE
DT-1078 Enable deleting secure casenotes

### DIFF
--- a/backend/api/caseNotesApi.js
+++ b/backend/api/caseNotesApi.js
@@ -66,7 +66,24 @@ const caseNotesApiFactory = client => {
 
   const getCaseNote = (context, offenderNo, caseNoteId) => get(context, `/case-notes/${offenderNo}/${caseNoteId}`)
 
-  return { getCaseNotes, getCaseNoteTypes, myCaseNoteTypes, addCaseNote, amendCaseNote, getCaseNote }
+  const deleteCaseNote = (context, offenderNo, caseNoteId) =>
+    client.sendDelete(context, `/case-notes/${offenderNo}/${caseNoteId}`).then(processResponse(context))
+
+  const deleteCaseNoteAmendment = (context, offenderNo, caseNoteAmendmentId) =>
+    client
+      .sendDelete(context, `/case-notes/amendment/${offenderNo}/${caseNoteAmendmentId}`)
+      .then(processResponse(context))
+
+  return {
+    getCaseNotes,
+    getCaseNoteTypes,
+    myCaseNoteTypes,
+    addCaseNote,
+    amendCaseNote,
+    getCaseNote,
+    deleteCaseNote,
+    deleteCaseNoteAmendment,
+  }
 }
 
 module.exports = { caseNotesApiFactory }

--- a/backend/api/oauthEnabledClient.js
+++ b/backend/api/oauthEnabledClient.js
@@ -136,6 +136,17 @@ const factory = ({ baseUrl, timeout }) => {
         })
     })
 
+  const sendDelete = (context, path) =>
+    new Promise((resolve, reject) => {
+      superagent
+        .delete(remoteUrl + path)
+        .set(getHeaders(context))
+        .end((error, response) => {
+          if (error) reject(errorLogger(error))
+          else if (response) resolve(resultLogger(response))
+        })
+    })
+
   const getStream = (context, path) =>
     new Promise((resolve, reject) => {
       superagent
@@ -187,6 +198,7 @@ const factory = ({ baseUrl, timeout }) => {
     pipe,
     post,
     put,
+    sendDelete,
   }
 }
 

--- a/backend/controllers/deleteCaseNote.js
+++ b/backend/controllers/deleteCaseNote.js
@@ -1,0 +1,87 @@
+const { capitalize, formatName, putLastNameFirst } = require('../utils')
+const { serviceUnavailableMessage } = require('../common-messages')
+
+module.exports = ({ prisonApi, caseNotesApi, oauthApi, logError }) => {
+  const index = async (req, res) => {
+    const { offenderNo, caseNoteId, caseNoteAmendmentId } = req.params
+
+    try {
+      const [caseNote, prisonerDetails] = await Promise.all([
+        caseNotesApi.getCaseNote(res.locals, offenderNo, caseNoteId),
+        prisonApi.getDetails(res.locals, offenderNo),
+      ])
+
+      const userRoles = await oauthApi.userRoles(res.locals).then(roles => roles.map(role => role.roleCode))
+
+      if (!userRoles.includes('DELETE_SENSITIVE_CASE_NOTES' || !caseNote.caseNoteId)) {
+        return res.render('notFound.njk', { url: req.headers.referer || `/prisoner/${offenderNo}/case-notes` })
+      }
+
+      let caseNoteData = {
+        prisonNumber: offenderNo,
+        prisonerNameForBreadcrumb: putLastNameFirst(prisonerDetails.firstName, prisonerDetails.lastName),
+        prisonerName: formatName(prisonerDetails.firstName, prisonerDetails.lastName),
+        typeSubType: `${capitalize(caseNote.typeDescription)}: ${capitalize(caseNote.subTypeDescription)}`,
+        backToCaseNotes: `/prisoner/${offenderNo}/case-notes`,
+        caseNoteId: caseNote.caseNoteId,
+      }
+
+      if (caseNoteAmendmentId) {
+        const amendmentToDelete =
+          caseNote.amendments &&
+          caseNote.amendments.find(amendment => amendment.caseNoteAmendmentId === Number(caseNoteAmendmentId))
+
+        if (!amendmentToDelete) {
+          return res.render('notFound.njk', { url: req.headers.referer || `/prisoner/${offenderNo}/case-notes` })
+        }
+
+        caseNoteData = {
+          ...caseNoteData,
+          caseNoteAmendmentId: amendmentToDelete.caseNoteAmendmentId,
+          text: amendmentToDelete.additionalNoteText,
+          date: amendmentToDelete.creationDateTime,
+          authorName: amendmentToDelete.authorName,
+        }
+      } else {
+        caseNoteData = {
+          ...caseNoteData,
+          text: caseNote.text,
+          date: caseNote.creationDateTime,
+          authorName: caseNote.authorName,
+          amendments:
+            caseNote.amendments &&
+            caseNote.amendments.map(amendment => ({
+              text: amendment.additionalNoteText,
+              date: amendment.creationDateTime,
+              authorName: amendment.authorName,
+            })),
+        }
+      }
+
+      return res.render('caseNoteDeleteConfirm.njk', caseNoteData)
+    } catch (error) {
+      logError(req.originalUrl, error, serviceUnavailableMessage)
+      return res.render('error.njk', { url: `/prisoner/${offenderNo}/case-notes` })
+    }
+  }
+
+  const post = async (req, res) => {
+    const { offenderNo, caseNoteId, caseNoteAmendmentId } = req.params
+    try {
+      if (caseNoteAmendmentId) {
+        await caseNotesApi.deleteCaseNoteAmendment(res.locals, offenderNo, caseNoteAmendmentId)
+      } else {
+        await caseNotesApi.deleteCaseNote(res.locals, offenderNo, caseNoteId)
+      }
+      return res.redirect(`/prisoner/${offenderNo}/case-notes`)
+    } catch (error) {
+      logError(req.originalUrl, error, serviceUnavailableMessage)
+      return res.render('error.njk', { url: `/prisoner/${offenderNo}/case-notes` })
+    }
+  }
+
+  return {
+    index,
+    post,
+  }
+}

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -30,7 +30,8 @@ const cellMoveRouter = require('./routes/cellMoveRouter')
 const establishmentRollRouter = require('./routes/establishmentRollRouter')
 const globalSearchRouter = require('./routes/globalSearchRouter')
 
-const amendCaseNNoteRouter = require('./routes/caseNoteAmendmentRouter')
+const amendCaseNoteRouter = require('./routes/caseNoteAmendmentRouter')
+const deleteCaseNoteRouter = require('./routes/caseNoteDeletionRouter')
 
 const currentUser = require('./middleware/currentUser')
 const systemOauthClient = require('./api/systemOauthClient')
@@ -201,7 +202,12 @@ const setup = ({
 
   router.use(
     '/prisoner/:offenderNo/case-notes/amend-case-note/:caseNoteId',
-    amendCaseNNoteRouter({ prisonApi, caseNotesApi, logError })
+    amendCaseNoteRouter({ prisonApi, caseNotesApi, logError })
+  )
+
+  router.use(
+    '/prisoner/:offenderNo/case-notes/delete-case-note/:caseNoteId/:caseNoteAmendmentId?',
+    deleteCaseNoteRouter({ prisonApi, caseNotesApi, oauthApi, logError })
   )
 
   router.get(['/content', '/content/:path'], contentController({ logError }))

--- a/backend/routes/caseNoteDeletionRouter.js
+++ b/backend/routes/caseNoteDeletionRouter.js
@@ -1,0 +1,16 @@
+const express = require('express')
+
+const deleteCaseNoteController = require('../controllers/deleteCaseNote')
+
+const router = express.Router({ mergeParams: true })
+
+const controller = ({ prisonApi, caseNotesApi, oauthApi, logError }) => {
+  const { index, post } = deleteCaseNoteController({ prisonApi, caseNotesApi, oauthApi, logError })
+
+  router.get('/', index)
+  router.post('/', post)
+
+  return router
+}
+
+module.exports = dependencies => controller(dependencies)

--- a/backend/routes/prisonerProfileRouter.js
+++ b/backend/routes/prisonerProfileRouter.js
@@ -75,6 +75,7 @@ const controller = ({
       paginationService,
       nunjucks,
       logError,
+      oauthApi,
     })
   )
   router.get(

--- a/backend/tests/caseNotesController.test.js
+++ b/backend/tests/caseNotesController.test.js
@@ -35,6 +35,7 @@ describe('Case notes controller', () => {
   const prisonerProfileService = {}
   const paginationService = {}
   const nunjucks = {}
+  const oauthApi = {}
 
   let controller
   let logError
@@ -73,7 +74,16 @@ describe('Case notes controller', () => {
     nunjucks.render = jest.fn()
     logError = jest.fn()
 
-    controller = controllerFactory({ caseNotesApi, prisonerProfileService, nunjucks, paginationService, logError })
+    oauthApi.userRoles = jest.fn().mockResolvedValue([{ roleCode: 'INACTIVE_BOOKINGS' }])
+
+    controller = controllerFactory({
+      caseNotesApi,
+      prisonerProfileService,
+      nunjucks,
+      paginationService,
+      logError,
+      oauthApi,
+    })
   })
 
   it('should render error template', async () => {
@@ -211,10 +221,12 @@ describe('Case notes controller', () => {
                 authorName: 'John Smith',
                 date: '1 December 2018',
                 day: 'Saturday',
+                deleteLink: false,
                 text: 'Some Additional Text',
                 time: '13:45',
               },
             ],
+            deleteLink: false,
             occurrenceDateTime: 'Tuesday 31 October 2017 - 01:30',
             printIncentiveLink: false,
             subTypeDescription: 'Key Worker Session',

--- a/backend/tests/deleteCaseNoteController.test.js
+++ b/backend/tests/deleteCaseNoteController.test.js
@@ -1,0 +1,241 @@
+const deleteCaseNoteController = require('../controllers/deleteCaseNote')
+
+describe('Delete case note', () => {
+  const caseNotesApi = {}
+  const prisonApi = {}
+  const oauthApi = {}
+
+  let controller
+  const req = {
+    originalUrl: 'http://localhost:3002/prisoner/case-notes/delete-case-note/1',
+  }
+  const res = {
+    locals: {},
+  }
+
+  beforeEach(() => {
+    caseNotesApi.getCaseNote = jest.fn().mockResolvedValue({
+      authorName: 'Tim Sphere',
+      caseNoteId: 1,
+      offenderIdentifier: 'A12345',
+      type: 'KA',
+      typeDescription: 'Key Worker',
+      subType: 'KS',
+      subTypeDescription: 'Key Worker Session',
+      source: 'OCNS',
+      text: 'This is some text',
+    })
+    caseNotesApi.deleteCaseNote = jest.fn()
+    caseNotesApi.deleteCaseNoteAmendment = jest.fn()
+    prisonApi.getDetails = jest.fn().mockResolvedValue({
+      firstName: 'BOB',
+      lastName: 'SMITH',
+    })
+    oauthApi.userRoles = jest.fn().mockResolvedValue([{ roleCode: 'DELETE_SENSITIVE_CASE_NOTES' }])
+
+    controller = deleteCaseNoteController({ caseNotesApi, prisonApi, logError: jest.fn(), oauthApi })
+
+    res.render = jest.fn()
+    res.redirect = jest.fn()
+    req.flash = jest.fn()
+    req.headers = {}
+
+    req.params = {
+      offenderNo: 'A12345',
+      caseNoteId: 1,
+    }
+  })
+
+  describe('index', () => {
+    it('should redirect user to the page not found page if the user does not have the delete casenotes role', async () => {
+      oauthApi.userRoles = jest.fn().mockResolvedValue([{ roleCode: 'ANOTHER_ROLE' }])
+
+      caseNotesApi.getCaseNote = jest.fn().mockResolvedValue({
+        authorUserId: '12345',
+        caseNoteId: 1,
+        offenderIdentifier: 'A12345',
+        type: 'KA',
+        typeDescription: 'Key Worker',
+        subType: 'KS',
+        subTypeDescription: 'Key Worker Session',
+        source: 'OCNS',
+        text: 'This is some text',
+      })
+
+      await controller.index(req, res)
+
+      expect(res.render).toHaveBeenCalledWith('notFound.njk', { url: '/prisoner/A12345/case-notes' })
+    })
+    it('should render error page on exception', async () => {
+      prisonApi.getDetails.mockRejectedValue(new Error('error'))
+      await controller.index(req, res)
+
+      expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/prisoner/A12345/case-notes' })
+    })
+
+    it('should make a request for an offenders case note', async () => {
+      await controller.index(req, res)
+
+      expect(caseNotesApi.getCaseNote).toHaveBeenCalledWith({}, 'A12345', 1)
+    })
+
+    it('should make a call to retrieve an prisoners name', async () => {
+      await controller.index(req, res)
+
+      expect(prisonApi.getDetails).toHaveBeenCalledWith({}, 'A12345')
+    })
+
+    it('should return case note details', async () => {
+      caseNotesApi.getCaseNote = jest.fn().mockResolvedValue({
+        caseNoteId: 1,
+        authorName: 'Tim Sphere',
+        creationDateTime: Date.UTC(2020, 11, 2),
+        offenderIdentifier: 'A12345',
+        type: 'KA',
+        typeDescription: 'Key Worker',
+        subType: 'KS',
+        subTypeDescription: 'Key Worker Session',
+        source: 'OCNS',
+        text: 'This is some text',
+        amendments: [
+          {
+            additionalNoteText: 'This is an amendment',
+            authorName: 'Tim Sphere',
+            creationDateTime: Date.UTC(2020, 11, 2),
+          },
+          {
+            additionalNoteText: 'This is an amendment',
+            authorName: 'Jane Cube',
+            creationDateTime: Date.UTC(2020, 11, 2),
+          },
+        ],
+      })
+
+      await controller.index(req, res)
+
+      expect(res.render).toHaveBeenCalledWith('caseNoteDeleteConfirm.njk', {
+        authorName: 'Tim Sphere',
+        date: Date.UTC(2020, 11, 2),
+        prisonerNameForBreadcrumb: 'Smith, Bob',
+        backToCaseNotes: '/prisoner/A12345/case-notes',
+        caseNoteId: 1,
+        prisonNumber: 'A12345',
+        typeSubType: 'Key worker: Key worker session',
+        text: 'This is some text',
+        prisonerName: 'Bob Smith',
+        amendments: [
+          {
+            text: 'This is an amendment',
+            authorName: 'Tim Sphere',
+            date: Date.UTC(2020, 11, 2),
+          },
+          {
+            text: 'This is an amendment',
+            authorName: 'Jane Cube',
+            date: Date.UTC(2020, 11, 2),
+          },
+        ],
+      })
+    })
+
+    describe('deleting casenote amendment', () => {
+      beforeEach(() => {
+        req.params = {
+          offenderNo: 'A12345',
+          caseNoteId: 1,
+          caseNoteAmendmentId: 234,
+        }
+      })
+
+      it('should return case note amendment details', async () => {
+        caseNotesApi.getCaseNote = jest.fn().mockResolvedValue({
+          caseNoteId: 1,
+          authorName: 'Tim Sphere',
+          creationDateTime: Date.UTC(2020, 11, 2),
+          offenderIdentifier: 'A12345',
+          type: 'KA',
+          typeDescription: 'Key Worker',
+          subType: 'KS',
+          subTypeDescription: 'Key Worker Session',
+          source: 'OCNS',
+          text: 'This is some text',
+          amendments: [
+            {
+              caseNoteAmendmentId: 234,
+              additionalNoteText: 'This is an incorrect amendment',
+              authorName: 'Graham Cone',
+              creationDateTime: Date.UTC(2020, 11, 5),
+            },
+            {
+              caseNoteAmendmentId: 567,
+              additionalNoteText: 'This is an amendment',
+              authorName: 'Jane Cube',
+              creationDateTime: Date.UTC(2020, 11, 2),
+            },
+          ],
+        })
+
+        await controller.index(req, res)
+
+        expect(res.render).toHaveBeenCalledWith('caseNoteDeleteConfirm.njk', {
+          authorName: 'Graham Cone',
+          date: Date.UTC(2020, 11, 5),
+          prisonerNameForBreadcrumb: 'Smith, Bob',
+          backToCaseNotes: '/prisoner/A12345/case-notes',
+          caseNoteId: 1,
+          caseNoteAmendmentId: 234,
+          prisonNumber: 'A12345',
+          typeSubType: 'Key worker: Key worker session',
+          text: 'This is an incorrect amendment',
+          prisonerName: 'Bob Smith',
+        })
+      })
+    })
+  })
+
+  describe('Post', () => {
+    describe('deleting casenote', () => {
+      beforeEach(() => {
+        req.params = {
+          offenderNo: 'A12345',
+          caseNoteId: 1,
+        }
+      })
+
+      it('should render error page on exception', async () => {
+        caseNotesApi.deleteCaseNote.mockRejectedValue(new Error('error'))
+        await controller.post(req, res)
+
+        expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/prisoner/A12345/case-notes' })
+      })
+
+      it('should delete the case note', async () => {
+        await controller.post(req, res)
+
+        expect(caseNotesApi.deleteCaseNote).toHaveBeenCalledWith({}, 'A12345', 1)
+      })
+
+      it('should redirect back to case notes on deletion', async () => {
+        await controller.post(req, res)
+
+        expect(res.redirect).toHaveBeenCalledWith('/prisoner/A12345/case-notes')
+      })
+    })
+
+    describe('deleting casenote amendment', () => {
+      beforeEach(() => {
+        req.params = {
+          offenderNo: 'A12345',
+          caseNoteId: 1,
+          caseNoteAmendmentId: 2345,
+        }
+      })
+
+      it('should delete the case note amendment', async () => {
+        await controller.post(req, res)
+
+        expect(caseNotesApi.deleteCaseNoteAmendment).toHaveBeenCalledWith({}, 'A12345', 2345)
+      })
+    })
+  })
+})

--- a/integration-tests/integration/prisonerProfile/caseNotesPage.spec.js
+++ b/integration-tests/integration/prisonerProfile/caseNotesPage.spec.js
@@ -109,6 +109,9 @@ context('A user can view prisoner case notes', () => {
         '/iep-slip?offenderNo=A12345&offenderName=Smith%2C%20John&location=HMP%20Moorland&casenoteId=12311312&issuedBy=undefined'
       )
 
+    rows.caseNoteDeleteLink().should('not.exist')
+    rows.caseNoteDeleteAmendmentLink().should('not.exist')
+
     const form = page.filterForm()
 
     form.typeSelect().select('Observations')
@@ -162,6 +165,29 @@ context('A user can view prisoner case notes', () => {
 
     page.viewAllCaseNotesTopLink().should('not.exist')
     page.viewAllCaseNotesBottomLink().should('not.exist')
+  })
+
+  it('should show a delete case note link if the case note is sensitive and the user has the correct role', () => {
+    cy.task('stubUserMeRoles', [{ roleCode: 'DELETE_SENSITIVE_CASE_NOTES' }])
+
+    cy.task('stubCaseNotes', {
+      totalElements: 1,
+      content: [{ ...caseNote, source: 'OCNS' }],
+    })
+    cy.visit(`/prisoner/${offenderNo}/case-notes`)
+    const page = CaseNotesPage.verifyOnPage('Smith, John')
+
+    const rows = page.getRows(0)
+
+    rows
+      .caseNoteDeleteLink()
+      .contains('Delete case note')
+      .should('have.attr', 'href', '/prisoner/A12345/case-notes/delete-case-note/12311312')
+
+    rows
+      .caseNoteDeleteAmendmentLink()
+      .contains('Delete amendment')
+      .should('have.attr', 'href', '/prisoner/A12345/case-notes/delete-case-note/12311312/123232')
   })
 
   it('should repopulate input fields with selected filters once applied has been clicked', () => {

--- a/integration-tests/mockApis/caseNotes.js
+++ b/integration-tests/mockApis/caseNotes.js
@@ -52,6 +52,28 @@ module.exports = {
       },
     })
   },
+  stubDeleteCaseNote: () => {
+    return stubFor({
+      request: {
+        method: 'DELETE',
+        urlPattern: '/casenotes/case-notes/A12345/.+?',
+      },
+      response: {
+        status: 200,
+      },
+    })
+  },
+  stubDeleteCaseNoteAmendment: () => {
+    return stubFor({
+      request: {
+        method: 'DELETE',
+        urlPattern: '/casenotes/case-notes/amendment/A12345/.+?',
+      },
+      response: {
+        status: 200,
+      },
+    })
+  },
   stubCaseNoteTypes: types => {
     return getFor({
       urlPattern: '/casenotes/case-notes/types',

--- a/integration-tests/pages/prisonerProfile/caseNotePage.js
+++ b/integration-tests/pages/prisonerProfile/caseNotePage.js
@@ -14,6 +14,8 @@ const caseNotePage = offenderName =>
       caseNoteDetails: () => cy.get('.case-notes-details'),
       caseNoteAddMoreDetailsLink: () => cy.get('[data-test="add-more-details"]'),
       caseNotePrintIncentiveLevelSlipLink: () => cy.get('[data-test="print-slip"]'),
+      caseNoteDeleteLink: () => cy.get('[data-test="delete"]'),
+      caseNoteDeleteAmendmentLink: () => cy.get('[data-test="delete-amendment"]'),
     }),
     noDataMessage: () => cy.get('[data-test="no-case-notes"]'),
     viewAllCaseNotesTopLink: () => cy.get('[data-test="view-all-case-notes-top-link"]'),

--- a/integration-tests/plugins/index.js
+++ b/integration-tests/plugins/index.js
@@ -298,6 +298,8 @@ module.exports = on => {
     stubVideoLinkAppointments: whereabouts.stubVideoLinkAppointments,
     stubCreateAlert: prisonApi.stubCreateAlert,
     stubCreateCaseNote: caseNotes.stubCreateCaseNote,
+    stubDeleteCaseNote: caseNotes.stubDeleteCaseNote,
+    stubDeleteCaseNoteAmendment: caseNotes.stubDeleteCaseNoteAmendment,
     stubCaseNoteTypesForUser: caseNotes.stubCaseNoteTypesForUser,
     stubGlobalSearch: offenderSearch.stubGlobalSearch,
     stubPrisonApiGlobalSearch: prisonApi.stubPrisonApiGlobalSearch,

--- a/views/caseNoteDeleteConfirm.njk
+++ b/views/caseNoteDeleteConfirm.njk
@@ -43,7 +43,7 @@
     </div>
 
     <div class="govuk-!-padding-bottom-1">
-        <pre class="govuk-body">{{ text }} </pre>
+        <pre class="govuk-body" data-qa="case-note-text">{{ text }} </pre>
     </div>
 
     {% for amendment in amendments %}

--- a/views/caseNoteDeleteConfirm.njk
+++ b/views/caseNoteDeleteConfirm.njk
@@ -1,0 +1,82 @@
+{% extends "./partials/layout.njk" %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set title = 'Delete case note' %}
+
+{% block beforeContent %}
+    {{ govukBreadcrumbs({
+        items: [
+            {
+                text: "Home",
+                href: notmUrl
+            },
+            {
+                text: prisonerNameForBreadcrumb,
+                href: backToCaseNotes
+            },
+            {
+                text: "Delete case note"
+            }
+        ]
+    }) }}
+{% endblock %}
+
+{% block content %}
+    {% if errors.length > 0 %}
+        {{ govukErrorSummary({
+            titleText: "There is a problem",
+            errorList: errors,
+            attributes: { 'data-qa-errors': true }
+        }) }}
+    {% endif %}
+    <h1 class="govuk-heading-l">Delete {{ prisonerName | possessive | safe }} case note {% if caseNoteAmendmentId %}amendment{% endif %}</h1>
+
+    <div class="govuk-body">
+        <span class="govuk-!-font-weight-bold">Prison number:</span> <span
+                data-qa="prison-number">{{ prisonNumber }}</span>
+    </div>
+
+    <div class="govuk-body">
+        <span class="govuk-!-font-weight-bold" data-qa="type-subtype">{{ typeSubType }}</span>
+    </div>
+
+    <div class="govuk-!-padding-bottom-1">
+        <pre class="govuk-body">{{ text }} </pre>
+    </div>
+
+    {% for amendment in amendments %}
+        <div class="govuk-!-margin-bottom-3">
+            <p class="govuk-body govuk-!-margin-bottom-1">
+                More details added:
+            </p>
+            <div class="govuk-!-padding-bottom-1" data-qa="amendment">
+                <pre class="govuk-body">{{ amendment.text }} </pre>
+            </div>
+        </div>
+    {% endfor %}
+
+    <div class="govuk-body">
+        <span class="govuk-!-font-weight-bold">Author:</span> <span
+                data-qa="author">{{ authorName }}</span>
+    </div>
+
+    <div class="govuk-body">
+        <span class="govuk-!-font-weight-bold">Date:</span> <span
+                data-qa="date">{{ date | formatDate('D MMMM YYYY HH:MM')}}</span>
+    </div>
+
+    <form action="{{ postAmendment }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+        {{ govukButton({ text: "Confirm delete", type: "submit" }) }}
+
+        {{ govukButton({
+            text: "Cancel",
+            href: backToCaseNotes,
+            classes: "govuk-button--secondary"
+        }) }}
+    </form>
+
+{% endblock %}

--- a/views/prisonerProfile/prisonerCaseNotes/caseNotes.njk
+++ b/views/prisonerProfile/prisonerCaseNotes/caseNotes.njk
@@ -26,6 +26,15 @@
             <p>
         {% endif %}
 
+        {% if caseNote.caseNoteDetailColumn.deleteLink %}
+            <p class="govuk-body">
+                <a class="govuk-link" data-test="delete"
+                href={{ caseNote.caseNoteDetailColumn.deleteLink }}>
+                    Delete case note
+                </a>
+            <p>
+        {% endif %}
+
         <p class="govuk-body">
             Happened: {{ caseNote.caseNoteDetailColumn.occurrenceDateTime }}
         </p>
@@ -182,7 +191,14 @@
                                 <pre class="govuk-body">{{ amendment.text }} </pre>
                             </div>
                         </div>
-
+                        {% if amendment.deleteLink %}
+                            <p class="govuk-body">
+                                <a class="govuk-link" data-test="delete-amendment"
+                                href={{ amendment.deleteLink }}>
+                                    Delete amendment
+                                </a>
+                            <p>
+                        {% endif %}
                         {% if loop.index === caseNote.caseNoteDetailColumn.amendments.length %}
                             {{ links(caseNote) }}
                         {% endif %}


### PR DESCRIPTION
Secure case notes and amendments can be deleted if the user has the role `DELETE_SENSITIVE_CASE_NOTES`. No other users will see this functionality.

Initially this will be given to admins, to save people on call from having to delete them via API calls which is easy to get wrong.

![Screenshot from 2020-12-02 16-43-48](https://user-images.githubusercontent.com/103082/101050665-847e0400-357c-11eb-981b-268a44684ae3.png)
![Screenshot from 2020-12-02 16-46-26](https://user-images.githubusercontent.com/103082/101050720-919af300-357c-11eb-9653-747486129e03.png)
![Screenshot from 2020-12-02 16-46-32](https://user-images.githubusercontent.com/103082/101050725-9495e380-357c-11eb-9ead-53af089938f0.png)
