### PR TITLE
DCS-759 Preventing middleware from being called twice

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -57,6 +57,13 @@ app.use(
   })
 )
 app.use(csrf())
+app.use((req, res, next) => {
+  if (typeof req.csrfToken === 'function') {
+    res.locals.csrfToken = req.csrfToken()
+  }
+  next()
+})
+
 app.use(
   routes({
     prisonApi: apis.prisonApi,

--- a/backend/index.js
+++ b/backend/index.js
@@ -25,6 +25,7 @@ const setupRedirects = require('./setupRedirects')
 const setupApiRoutes = require('./setupApiRoutes')
 const setupReactRoutes = require('./setupReactRoutes')
 const phaseNameSetup = require('./phaseNameSetup')
+const currentUser = require('./middleware/currentUser')
 
 const pageNotFound = require('./setUpPageNotFound')
 
@@ -45,6 +46,8 @@ app.use(setupStaticContent())
 app.use(setupWebSession())
 app.use(setupAuth({ oauthApi: apis.oauthApi, tokenVerificationApi: apis.tokenVerificationApi }))
 app.use(setupWebpackForDev())
+
+app.use(currentUser({ prisonApi: apis.prisonApi, oauthApi: apis.oauthApi }))
 app.use(
   setupApiRoutes({
     prisonApi: apis.prisonApi,

--- a/backend/middleware/currentUser.js
+++ b/backend/middleware/currentUser.js
@@ -35,10 +35,6 @@ module.exports = ({ prisonApi, oauthApi }) => {
         req.session.allCaseloads = allCaseloads
       }
 
-      if (typeof req.csrfToken === 'function') {
-        res.locals.csrfToken = req.csrfToken()
-      }
-
       const activeCaseLoad = await getActiveCaseload(req, res)
 
       res.locals.user = {

--- a/backend/middleware/currentUser.js
+++ b/backend/middleware/currentUser.js
@@ -17,7 +17,6 @@ module.exports = ({ prisonApi, oauthApi }) => {
       await prisonApi.setActiveCaseload(res.locals, potentialCaseLoad)
 
       req.session.userDetails.activeCaseLoadId = firstCaseLoadId
-      req.session.data = null
 
       return potentialCaseLoad
     }

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -33,7 +33,6 @@ const globalSearchRouter = require('./routes/globalSearchRouter')
 const amendCaseNoteRouter = require('./routes/caseNoteAmendmentRouter')
 const deleteCaseNoteRouter = require('./routes/caseNoteDeletionRouter')
 
-const currentUser = require('./middleware/currentUser')
 const systemOauthClient = require('./api/systemOauthClient')
 const handleErrors = require('./middleware/asyncHandler')
 const { notifyClient } = require('./shared/notifyClient')
@@ -55,8 +54,6 @@ const setup = ({
   socApi,
   offenderSearchApi,
 }) => {
-  router.use(currentUser({ prisonApi, oauthApi }))
-
   router.use(async (req, res, next) => {
     res.locals = {
       ...res.locals,

--- a/backend/setupApiRoutes.js
+++ b/backend/setupApiRoutes.js
@@ -23,8 +23,6 @@ const endDateController = require('./controllers/appointments/endDate')
 
 const existingEventsService = require('./services/existingEventsService')
 
-const currentUser = require('./middleware/currentUser')
-
 const controllerFactory = require('./controllers/controller').factory
 
 const contextProperties = require('./contextProperties')
@@ -44,8 +42,6 @@ const setup = ({ prisonApi, whereaboutsApi, oauthApi, caseNotesApi }) => {
     caseNotesApi,
     logError,
   })
-
-  router.use(currentUser({ prisonApi, oauthApi }))
 
   router.use(async (req, res, next) => {
     res.locals = {


### PR DESCRIPTION
Removing unnecessary session data clean and fixing issue where middleware called twice. 

Two routes on the same path will share any middleware added by `router.use`