### PR TITLE
NN-3125 respond with correct http status codes

### DIFF
--- a/backend/controllers/alert.js
+++ b/backend/controllers/alert.js
@@ -244,6 +244,7 @@ const alertFactory = (oauthApi, prisonApi, referenceCodesService) => {
       })
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       return res.render('error.njk', { url: `${getOffenderUrl(offenderNo)}/alerts` })
     }
   }
@@ -376,6 +377,7 @@ const alertFactory = (oauthApi, prisonApi, referenceCodesService) => {
       )
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       return res.render('error.njk', { url: `${getOffenderUrl(offenderNo)}/create-alert` })
     }
 

--- a/backend/controllers/amendmentCaseNote.js
+++ b/backend/controllers/amendmentCaseNote.js
@@ -38,6 +38,7 @@ module.exports = ({ prisonApi, caseNotesApi, logError }) => {
       })
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       return res.render('error.njk', { url: `/prisoner/${offenderNo}/case-notes` })
     }
   }
@@ -87,6 +88,7 @@ module.exports = ({ prisonApi, caseNotesApi, logError }) => {
       return makeAmendment(req, res, { offenderNo, caseNoteId, moreDetail, maximumLengthValidation })
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       return res.render('error.njk', { url: `/prisoner/${offenderNo}/case-notes` })
     }
   }

--- a/backend/controllers/appointments/addAppointment.js
+++ b/backend/controllers/appointments/addAppointment.js
@@ -106,6 +106,8 @@ const addAppointmentFactory = (appointmentsService, existingEventsService, priso
     const { offenderNo } = req.params
     if (error) logError(req.originalUrl, error, serviceUnavailableMessage)
 
+    res.status(500)
+
     return res.render('error.njk', { url: getOffenderUrl(offenderNo) })
   }
 

--- a/backend/controllers/appointments/bulkAppointmentsAddDetails.js
+++ b/backend/controllers/appointments/bulkAppointmentsAddDetails.js
@@ -84,6 +84,7 @@ const bulkAppointmentsAddDetailsFactory = (appointmentsService, oauthApi, logErr
       })
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       res.render('error.njk', {
         url: req.originalUrl,
       })
@@ -188,6 +189,7 @@ const bulkAppointmentsAddDetailsFactory = (appointmentsService, oauthApi, logErr
       })
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       res.render('error.njk', {
         url: req.originalUrl,
       })

--- a/backend/controllers/appointments/bulkAppointmentsClashes.js
+++ b/backend/controllers/appointments/bulkAppointmentsClashes.js
@@ -13,6 +13,8 @@ const bulkAppointmentsClashesFactory = (prisonApi, logError) => {
   const renderError = (req, res, error) => {
     if (error) logError(req.originalUrl, error, serviceUnavailableMessage)
 
+    res.status(500)
+
     return res.render('error.njk', { url: '/bulk-appointments/need-to-upload-file' })
   }
 

--- a/backend/controllers/appointments/bulkAppointmentsConfirm.js
+++ b/backend/controllers/appointments/bulkAppointmentsConfirm.js
@@ -25,6 +25,7 @@ const bulkAppointmentsConfirmFactory = (prisonApi, logError) => {
 
   const renderError = (req, res, error) => {
     if (error) logError(req.originalUrl, error, 'Sorry, the service is unavailable')
+    res.status(500)
 
     return res.render('error.njk', { url: '/bulk-appointments/need-to-upload-file' })
   }

--- a/backend/controllers/appointments/prepostAppoinments.js
+++ b/backend/controllers/appointments/prepostAppoinments.js
@@ -188,6 +188,7 @@ const prepostAppointmentsFactory = ({
       })
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       res.render('error.njk', {
         url: authSource === 'nomis' ? `/offenders/${offenderNo}/add-appointment` : '/videolink/prisoner-search',
       })
@@ -438,6 +439,7 @@ const prepostAppointmentsFactory = ({
       return res.redirect(`/offenders/${offenderNo}/confirm-appointment`)
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       return res.render('error.njk', {
         url: authSource === 'nomis' ? `/offenders/${offenderNo}/add-appointment` : '/videolink/prisoner-search',
       })

--- a/backend/controllers/attendance/attendanceStatistics.js
+++ b/backend/controllers/attendance/attendanceStatistics.js
@@ -292,6 +292,7 @@ const attendanceStatisticsFactory = (oauthApi, prisonApi, whereaboutsApi, logErr
       })
     } catch (error) {
       logError(req.originalUrl, error, 'Sorry, the service is unavailable')
+      res.status(500)
       return res.render('error.njk', {
         url: attendanceReasonStatsUrl,
       })
@@ -365,6 +366,7 @@ const attendanceStatisticsFactory = (oauthApi, prisonApi, whereaboutsApi, logErr
       })
     } catch (error) {
       logError(req.originalUrl, error, 'Sorry, the service is unavailable')
+      res.status(500)
       return res.render('error.njk', {
         url: `${attendanceReasonStatsUrl}/reason/${reason}`,
       })
@@ -469,6 +471,7 @@ const attendanceStatisticsFactory = (oauthApi, prisonApi, whereaboutsApi, logErr
       })
     } catch (error) {
       logError(req.originalUrl, error, 'Sorry, the service is unavailable')
+      res.status(500)
       return res.render('error.njk', {
         url: `${attendanceReasonStatsUrl}/suspended`,
       })

--- a/backend/controllers/caseNote.js
+++ b/backend/controllers/caseNote.js
@@ -63,6 +63,7 @@ const caseNoteFactory = (prisonApi, caseNotesApi) => {
       })
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       return res.render('error.njk', { url: `${getOffenderUrl(offenderNo)}/case-notes` })
     }
   }
@@ -237,6 +238,7 @@ const caseNoteFactory = (prisonApi, caseNotesApi) => {
       })
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       return res.render('error.njk', { url: `${getOffenderUrl(offenderNo)}/add-case-note` })
     }
 

--- a/backend/controllers/cellMove/cellMoveConfirmation.js
+++ b/backend/controllers/cellMove/cellMoveConfirmation.js
@@ -18,6 +18,8 @@ module.exports = ({ prisonApi, logError }) => async (req, res) => {
   } catch (error) {
     if (error) logError(req.originalUrl, error, 'Failed to load cell move confirmation page')
 
+    res.status(400)
+
     return res.render('error.njk', {
       url: `/prisoner/${offenderNo}/cell-move/search-for-cell`,
       homeUrl: `/prisoner/${offenderNo}`,

--- a/backend/controllers/cellMove/cellNotAvailable.js
+++ b/backend/controllers/cellMove/cellNotAvailable.js
@@ -18,6 +18,8 @@ module.exports = ({ prisonApi, logError }) => async (req, res) => {
   } catch (error) {
     if (error) logError(req.originalUrl, error, 'Failed to load offender details on cell not available page')
 
+    res.status(500)
+
     return res.render('error.njk', {
       url: `/prisoner/${offenderNo}/cell-move/search-for-cell`,
       homeUrl: `/prisoner/${offenderNo}`,

--- a/backend/controllers/cellMove/confirmCellMove.js
+++ b/backend/controllers/cellMove/confirmCellMove.js
@@ -138,6 +138,8 @@ module.exports = ({ prisonApi, whereaboutsApi, caseNotesApi, logError }) => {
     } catch (error) {
       if (error) logError(req.originalUrl, error, `Failed to make cell move to ${cellId}`)
 
+      res.status(500)
+
       return res.render('error.njk', {
         url: `/prisoner/${offenderNo}/cell-move/select-cell`,
         homeUrl: `/prisoner/${offenderNo}`,

--- a/backend/controllers/cellMove/considerRisks.js
+++ b/backend/controllers/cellMove/considerRisks.js
@@ -175,6 +175,8 @@ module.exports = ({ prisonApi, logError }) => {
     } catch (error) {
       if (error) logError(req.originalUrl, error, serviceUnavailableMessage)
 
+      res.status(500)
+
       return res.render('error.njk', {
         url: `/prisoner/${offenderNo}/cell-history`,
         homeUrl: `/prisoner/${offenderNo}`,

--- a/backend/controllers/cellMove/cswapConfirmation.js
+++ b/backend/controllers/cellMove/cswapConfirmation.js
@@ -17,6 +17,8 @@ module.exports = ({ prisonApi, logError }) => async (req, res) => {
   } catch (error) {
     if (error) logError(req.originalUrl, error, 'Failed to load cswap confirmation page')
 
+    res.status(500)
+
     return res.render('error.njk', {
       url: `/prisoner/${offenderNo}/cell-move/search-for-cell`,
       homeUrl: `/prisoner/${offenderNo}`,

--- a/backend/controllers/cellMove/searchForCell.js
+++ b/backend/controllers/cellMove/searchForCell.js
@@ -59,6 +59,8 @@ module.exports = ({ oauthApi, prisonApi, whereaboutsApi, logError }) => async (r
   } catch (error) {
     if (error) logError(req.originalUrl, error, serviceUnavailableMessage)
 
+    res.status(500)
+
     return res.render('error.njk', {
       url: `/prisoner/${offenderNo}/cell-move/search-for-cell`,
       homeUrl: `/prisoner/${offenderNo}`,

--- a/backend/controllers/cellMove/selectCell.js
+++ b/backend/controllers/cellMove/selectCell.js
@@ -225,6 +225,9 @@ module.exports = ({ oauthApi, prisonApi, whereaboutsApi, logError }) => async (r
     })
   } catch (error) {
     if (error) logError(req.originalUrl, error, serviceUnavailableMessage)
+
+    res.status(500)
+
     return res.render('error.njk', {
       url: `/prisoner/${offenderNo}/cell-move/search-for-cell`,
       homeUrl: `/prisoner/${offenderNo}`,

--- a/backend/controllers/cellMove/viewCellSharingAssessmentDetails.js
+++ b/backend/controllers/cellMove/viewCellSharingAssessmentDetails.js
@@ -38,6 +38,8 @@ module.exports = ({ prisonApi, logError }) => async (req, res) => {
   } catch (error) {
     if (error) logError(req.originalUrl, error, serviceUnavailableMessage)
 
+    res.status(500)
+
     return res.render('error.njk', {
       url: `/prisoner/${offenderNo}/cell-move/search-for-cell`,
       homeUrl: `/prisoner/${offenderNo}`,

--- a/backend/controllers/cellMove/viewNonAssociations.js
+++ b/backend/controllers/cellMove/viewNonAssociations.js
@@ -59,6 +59,8 @@ module.exports = ({ prisonApi, logError }) => async (req, res) => {
   } catch (error) {
     if (error) logError(req.originalUrl, error, serviceUnavailableMessage)
 
+    res.status(500)
+
     return res.render('error.njk', {
       url: `/prisoner/${offenderNo}/cell-move/non-associations`,
       homeUrl: `/prisoner/${offenderNo}`,

--- a/backend/controllers/cellMove/viewOffenderDetails.js
+++ b/backend/controllers/cellMove/viewOffenderDetails.js
@@ -36,6 +36,8 @@ module.exports = ({ prisonApi, logError }) => async (req, res) => {
   } catch (error) {
     if (error) logError(req.originalUrl, error, serviceUnavailableMessage)
 
+    res.status(500)
+
     return res.render('error.njk', {
       url: `/prisoner/${offenderNo}/cell-move/search-for-cell`,
       homeUrl: `/prisoner/${offenderNo}`,

--- a/backend/controllers/changeCaseload.js
+++ b/backend/controllers/changeCaseload.js
@@ -29,6 +29,7 @@ const changeCaseloadFactory = (prisonApi, logError) => {
       })
     } catch (error) {
       logError(req.originalUrl, error, 'Sorry, the service is unavailable')
+      res.status(500)
       return res.render('error.njk', {
         url: '/change-caseload',
       })
@@ -48,6 +49,7 @@ const changeCaseloadFactory = (prisonApi, logError) => {
       res.redirect(config.app.notmEndpointUrl)
     } else {
       logError(req.originalUrl, 'Caseload ID is missing')
+      res.status(500)
       res.render('error.njk', {
         url: '/change-caseload',
       })

--- a/backend/controllers/content.js
+++ b/backend/controllers/content.js
@@ -40,6 +40,7 @@ module.exports = ({ logError }) => async (req, res) => {
     return res.render('content.njk', { content, dpsUrl, title })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: dpsUrl })
   }
 }

--- a/backend/controllers/covid/covidDashboardController.js
+++ b/backend/controllers/covid/covidDashboardController.js
@@ -34,6 +34,7 @@ module.exports = ({ covidService, logError }) => {
       return res.render('covid/dashboard.njk', { title: 'Current breakdown of COVID units', dashboardStats })
     } catch (e) {
       logError(req.originalUrl, e, 'Failed to load dashboard stats')
+      res.status(500)
       return res.render('error.njk', { url: '/current-covid-units' })
     }
   }

--- a/backend/controllers/covid/notInUnitController.js
+++ b/backend/controllers/covid/notInUnitController.js
@@ -21,6 +21,7 @@ module.exports = ({ covidService, logError }) => {
       })
     } catch (e) {
       logError(req.originalUrl, e, 'Failed to load not in unit list')
+      res.status(500)
       return res.render('error.njk', { url: '/current-covid-units/not-in-unit' })
     }
   }

--- a/backend/controllers/covid/protectiveIsolationUnitController.js
+++ b/backend/controllers/covid/protectiveIsolationUnitController.js
@@ -31,6 +31,7 @@ module.exports = ({ covidService, logError, nowGetter = moment }) => {
       })
     } catch (e) {
       logError(req.originalUrl, e, 'Failed to load protective isolation list')
+      res.status(500)
       return res.render('error.njk', { url: '/current-covid-units/protective-isolation-unit' })
     }
   }

--- a/backend/controllers/covid/refusingToShieldController.js
+++ b/backend/controllers/covid/refusingToShieldController.js
@@ -20,6 +20,7 @@ module.exports = ({ covidService, logError }) => {
       })
     } catch (e) {
       logError(req.originalUrl, e, 'Failed to load list of prisoners refusing to shield')
+      res.status(500)
       return res.render('error.njk', { url: '/current-covid-units/refusing-to-shield' })
     }
   }

--- a/backend/controllers/covid/reverseCohortingUnitController.js
+++ b/backend/controllers/covid/reverseCohortingUnitController.js
@@ -34,6 +34,7 @@ module.exports = ({ covidService, logError }) => {
       })
     } catch (e) {
       logError(req.originalUrl, e, 'Failed to load reverse cohorting list')
+      res.status(500)
       return res.render('error.njk', { url: '/current-covid-units/reverse-cohorting-unit' })
     }
   }

--- a/backend/controllers/covid/shieldingUnitController.js
+++ b/backend/controllers/covid/shieldingUnitController.js
@@ -22,6 +22,7 @@ module.exports = ({ covidService, logError }) => {
       })
     } catch (e) {
       logError(req.originalUrl, e, 'Failed to load shielding list')
+      res.status(500)
       return res.render('error.njk', { url: '/current-covid-units/shielding-unit' })
     }
   }

--- a/backend/controllers/deleteCaseNote.js
+++ b/backend/controllers/deleteCaseNote.js
@@ -61,6 +61,7 @@ module.exports = ({ prisonApi, caseNotesApi, oauthApi, logError }) => {
       return res.render('caseNoteDeleteConfirm.njk', caseNoteData)
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       return res.render('error.njk', { url: `/prisoner/${offenderNo}/case-notes` })
     }
   }
@@ -76,6 +77,7 @@ module.exports = ({ prisonApi, caseNotesApi, oauthApi, logError }) => {
       return res.redirect(`/prisoner/${offenderNo}/case-notes`)
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       return res.render('error.njk', { url: `/prisoner/${offenderNo}/case-notes` })
     }
   }

--- a/backend/controllers/establishmentRoll/currentlyOut.js
+++ b/backend/controllers/establishmentRoll/currentlyOut.js
@@ -39,6 +39,8 @@ module.exports = ({ movementsService, logError }) => async (req, res) => {
   } catch (error) {
     if (error) logError(req.originalUrl, error, 'Failed to load currently out page')
 
+    res.status(500)
+
     return res.render('error.njk', {
       url: '/establishment-roll/currently-out',
       homeUrl: dpsUrl,

--- a/backend/controllers/establishmentRoll/dashboard.js
+++ b/backend/controllers/establishmentRoll/dashboard.js
@@ -85,7 +85,9 @@ module.exports = ({ prisonApi, logError }) => async (req, res) => {
       rows,
     })
   } catch (error) {
-    if (error) logError(req.originalUrl, error, 'Failed to load estalishment roll count page')
+    if (error) logError(req.originalUrl, error, 'Failed to load establishment roll count page')
+
+    res.status(500)
 
     return res.render('error.njk', {
       url: '/establishment-roll',

--- a/backend/controllers/establishmentRoll/enRoute.js
+++ b/backend/controllers/establishmentRoll/enRoute.js
@@ -42,6 +42,8 @@ module.exports = ({ movementsService, logError }) => async (req, res) => {
   } catch (error) {
     if (error) logError(req.originalUrl, error, 'Failed to load en route page')
 
+    res.status(500)
+
     return res.render('error.njk', {
       url: '/establishment-roll/en-route',
       homeUrl: dpsUrl,

--- a/backend/controllers/establishmentRoll/inReceptionController.js
+++ b/backend/controllers/establishmentRoll/inReceptionController.js
@@ -28,6 +28,7 @@ module.exports = ({ movementsService, logError }) => async (req, res) => {
     })
   } catch (error) {
     logError(req.originalUrl, error, 'Error trying to load in-reception page')
+    res.status(500)
     return res.render('error.njk', { url: '/establishment-roll/in-reception' })
   }
 }

--- a/backend/controllers/establishmentRoll/inToday.js
+++ b/backend/controllers/establishmentRoll/inToday.js
@@ -38,6 +38,8 @@ module.exports = ({ movementsService, logError }) => async (req, res) => {
   } catch (error) {
     if (error) logError(req.originalUrl, error, 'Failed to load in today page')
 
+    res.status(500)
+
     return res.render('error.njk', {
       url: '/establishment-roll/in-today',
       homeUrl: dpsUrl,

--- a/backend/controllers/establishmentRoll/outToday.js
+++ b/backend/controllers/establishmentRoll/outToday.js
@@ -36,6 +36,8 @@ module.exports = ({ movementsService, logError }) => async (req, res) => {
   } catch (error) {
     if (error) logError(req.originalUrl, error, 'Failed to load out today page')
 
+    res.status(500)
+
     return res.render('error.njk', {
       url: '/establishment-roll/out-today',
       homeUrl: dpsUrl,

--- a/backend/controllers/establishmentRoll/totalCurrentlyOut.js
+++ b/backend/controllers/establishmentRoll/totalCurrentlyOut.js
@@ -39,6 +39,8 @@ module.exports = ({ movementsService, logError }) => async (req, res) => {
   } catch (error) {
     if (error) logError(req.originalUrl, error, 'Failed to load total currently out page')
 
+    res.status(500)
+
     return res.render('error.njk', {
       url: '/establishment-roll/total-currently-out',
       homeUrl: dpsUrl,

--- a/backend/controllers/globalSearch.js
+++ b/backend/controllers/globalSearch.js
@@ -123,6 +123,8 @@ module.exports = ({ paginationService, offenderSearchApi, oauthApi, logError }) 
     } catch (error) {
       if (error) logError(req.originalUrl, error, 'Failed to load global search page')
 
+      res.status(500)
+
       return res.render('error.njk', { url: '/global-search' })
     }
   }

--- a/backend/controllers/prisonerProfile/adjudicationHistory.js
+++ b/backend/controllers/prisonerProfile/adjudicationHistory.js
@@ -98,6 +98,8 @@ module.exports = ({ adjudicationHistoryService, prisonApi, logError, paginationS
   } catch (error) {
     if (error) logError(req.originalUrl, error, 'Failed to load adjudication history page')
 
+    res.status(500)
+
     return res.render('error.njk', {
       url: `/offenders/${offenderNo}/adjudications`,
       homeUrl: `/prisoner/${offenderNo}`,

--- a/backend/controllers/prisonerProfile/prisonerAdjudicationDetails.js
+++ b/backend/controllers/prisonerProfile/prisonerAdjudicationDetails.js
@@ -53,6 +53,7 @@ module.exports = ({ prisonApi, logError }) => async (req, res) => {
     })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: `/prisoner/${offenderNo}` })
   }
 }

--- a/backend/controllers/prisonerProfile/prisonerAlerts.js
+++ b/backend/controllers/prisonerProfile/prisonerAlerts.js
@@ -116,6 +116,7 @@ module.exports = ({
     })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: `/prisoner/${offenderNo}/alerts` })
   }
 }

--- a/backend/controllers/prisonerProfile/prisonerCaseNotes.js
+++ b/backend/controllers/prisonerProfile/prisonerCaseNotes.js
@@ -154,6 +154,7 @@ module.exports = ({ caseNotesApi, prisonerProfileService, paginationService, nun
       })
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       return res.render('error.njk', { url: `/prisoner/${offenderNo}/case-notes` })
     }
   }

--- a/backend/controllers/prisonerProfile/prisonerCellHistory.js
+++ b/backend/controllers/prisonerProfile/prisonerCellHistory.js
@@ -94,6 +94,7 @@ module.exports = ({ oauthApi, prisonApi, logError, page = 0 }) => async (req, re
     })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: `/prisoner/${offenderNo}` })
   }
 }

--- a/backend/controllers/prisonerProfile/prisonerChangeIncentiveLevelDetails.js
+++ b/backend/controllers/prisonerProfile/prisonerChangeIncentiveLevelDetails.js
@@ -9,6 +9,7 @@ module.exports = ({ prisonApi, logError }) => {
   const renderError = (req, res, error) => {
     const { offenderNo } = req.params
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: `/prisoner/${offenderNo}` })
   }
 

--- a/backend/controllers/prisonerProfile/prisonerFinances/prisonerDamageObligations.js
+++ b/backend/controllers/prisonerProfile/prisonerFinances/prisonerDamageObligations.js
@@ -62,6 +62,7 @@ module.exports = ({ prisonApi, logError }) => async (req, res) => {
     })
   } catch (error) {
     logError(req.originalUrl, error, 'Damage obligations page - Prisoner finances')
+    res.status(500)
     return res.render('error.njk', { url: `/prisoner/${offenderNo}` })
   }
 }

--- a/backend/controllers/prisonerProfile/prisonerFullImage.js
+++ b/backend/controllers/prisonerProfile/prisonerFullImage.js
@@ -16,6 +16,7 @@ module.exports = ({ prisonApi, logError }) => async (req, res) => {
     })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: dpsUrl })
   }
 }

--- a/backend/controllers/prisonerProfile/prisonerIncentiveLevelDetails.js
+++ b/backend/controllers/prisonerProfile/prisonerIncentiveLevelDetails.js
@@ -127,6 +127,7 @@ module.exports = ({ prisonApi, oauthApi, logError }) => async (req, res) => {
     })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: `/prisoner/${offenderNo}` })
   }
 }

--- a/backend/controllers/prisonerProfile/prisonerLocationHistory.js
+++ b/backend/controllers/prisonerProfile/prisonerLocationHistory.js
@@ -128,6 +128,7 @@ module.exports = ({ prisonApi, whereaboutsApi, caseNotesApi, logError }) => asyn
     })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: `/prisoner/${offenderNo}` })
   }
 }

--- a/backend/controllers/prisonerProfile/prisonerProfessionalContacts.js
+++ b/backend/controllers/prisonerProfile/prisonerProfessionalContacts.js
@@ -106,6 +106,7 @@ module.exports = ({ prisonApi, personService, allocationManagerApi, logError }) 
     })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: '/' })
   }
 }

--- a/backend/controllers/prisonerProfile/prisonerQuickLook.js
+++ b/backend/controllers/prisonerProfile/prisonerQuickLook.js
@@ -275,10 +275,12 @@ module.exports = ({ prisonerProfileService, prisonApi, logError }) => async (req
       })
     } catch (error) {
       logError(req.originalUrl, error, serviceUnavailableMessage)
+      res.status(500)
       return res.render('error.njk', { url: `/prisoner/${offenderNo}` })
     }
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: dpsUrl })
   }
 }

--- a/backend/controllers/prisonerProfile/prisonerSchedule.js
+++ b/backend/controllers/prisonerProfile/prisonerSchedule.js
@@ -52,6 +52,7 @@ module.exports = ({ prisonApi, logError }) => async (req, res) => {
     })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: '/' })
   }
 }

--- a/backend/controllers/prisonerProfile/prisonerSentenceAndRelease.js
+++ b/backend/controllers/prisonerProfile/prisonerSentenceAndRelease.js
@@ -43,6 +43,7 @@ module.exports = ({ prisonerProfileService, prisonApi, systemOauthClient, logErr
     })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: `/prisoner/${offenderNo}/sentence-and-release` })
   }
 }

--- a/backend/controllers/prisonerProfile/prisonerVisits.js
+++ b/backend/controllers/prisonerProfile/prisonerVisits.js
@@ -98,6 +98,7 @@ module.exports = ({ prisonApi, logError, pageSize = 20 }) => async (req, res) =>
     })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: `/prisoner/${offenderNo}` })
   }
 }

--- a/backend/controllers/retentionReasons.js
+++ b/backend/controllers/retentionReasons.js
@@ -44,6 +44,7 @@ const retentionReasonsFactory = (prisonApi, dataComplianceApi, logError) => {
   const renderError = (req, res, error) => {
     const { offenderNo } = req.params
     if (error) logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: getRetentionReasonsUrl(offenderNo) })
   }
 

--- a/backend/controllers/search/prisonerSearch.js
+++ b/backend/controllers/search/prisonerSearch.js
@@ -114,6 +114,8 @@ module.exports = ({ paginationService, prisonApi, logError }) => {
       if (error && (error.code !== 'ECONNRESET' && !(error.stack && error.stack.toLowerCase().includes('timeout'))))
         logError(req.originalUrl, error, serviceUnavailableMessage)
 
+      res.status(500)
+
       return res.render('error.njk', { url: '/', homeUrl: '/' })
     }
   }

--- a/backend/routes/appointments/bulkAppointmentsSlipsRouter.js
+++ b/backend/routes/appointments/bulkAppointmentsSlipsRouter.js
@@ -43,6 +43,7 @@ module.exports = ({ prisonApi, logError }) => async (req, res) => {
       appointmentDetails: { ...appointmentDetails, createdBy, prisonersListed: prisonersListedWithCellInfo },
     })
   } catch (error) {
+    res.status(500)
     return renderError(error)
   }
 }

--- a/backend/routes/appointments/viewAppointmentsRouter.js
+++ b/backend/routes/appointments/viewAppointmentsRouter.js
@@ -140,6 +140,7 @@ module.exports = ({ prisonApi, whereaboutsApi, oauthApi, logError }) => async (r
     })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk', { url: '/appointments' })
   }
 }

--- a/backend/routes/attendanceChangesRouter.js
+++ b/backend/routes/attendanceChangesRouter.js
@@ -105,6 +105,7 @@ module.exports = ({ prisonApi, whereaboutsApi, oauthApi, logError }) => async (r
     })
   } catch (error) {
     logError(req.originalUrl, error, serviceUnavailableMessage)
+    res.status(500)
     return res.render('error.njk')
   }
 }

--- a/backend/setUpPageNotFound.js
+++ b/backend/setUpPageNotFound.js
@@ -1,1 +1,4 @@
-module.exports = (req, res) => res.render('notFound.njk', { url: req.headers.referer || '/' })
+module.exports = (req, res) => {
+  res.status(404)
+  res.render('notFound.njk', { url: req.headers.referer || '/' })
+}

--- a/backend/tests/addAppointment.test.js
+++ b/backend/tests/addAppointment.test.js
@@ -90,8 +90,11 @@ describe('Add appointment', () => {
       })
 
       it('should render the error template', async () => {
+        res.status = jest.fn()
+
         await controller.index(req, res)
 
+        expect(res.status).toHaveBeenCalledWith(500)
         expect(logError).toHaveBeenCalledWith('http://localhost', new Error('Network error'), serviceUnavailableMessage)
         expect(res.render).toHaveBeenCalledWith('error.njk', { url: `/prisoner/${offenderNo}` })
       })
@@ -189,9 +192,11 @@ describe('Add appointment', () => {
         jest.spyOn(Date, 'now').mockImplementation(() => 33103209600000) // Friday 3019-01-01T00:00:00.000Z
         req.body = { ...validBody, date: moment().format(DAY_MONTH_YEAR) }
         prisonApi.addAppointments.mockImplementation(() => Promise.reject(new Error('Network error')))
+        res.status = jest.fn()
 
         await controller.post(req, res)
 
+        expect(res.status).toHaveBeenCalledWith(500)
         expect(logError).toHaveBeenCalledWith('http://localhost', new Error('Network error'), serviceUnavailableMessage)
         expect(res.render).toHaveBeenCalledWith('error.njk', { url: `/prisoner/${offenderNo}` })
 

--- a/backend/tests/adjudicationHistoryController.test.js
+++ b/backend/tests/adjudicationHistoryController.test.js
@@ -194,9 +194,12 @@ describe('Adjudications history controller', () => {
 
     adjudicationHistoryService.getAdjudications.mockRejectedValue(error)
 
+    res.status = jest.fn()
+
     await controller(req, res)
 
     expect(logError).toHaveBeenCalledWith('http://localhost', error, 'Failed to load adjudication history page')
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       homeUrl: '/prisoner/A12345',
       url: '/offenders/A12345/adjudications',

--- a/backend/tests/alert.test.js
+++ b/backend/tests/alert.test.js
@@ -356,8 +356,11 @@ describe('alert management', () => {
 
       const req = { ...mockCreateReq, params: { offenderNo }, headers: {} }
 
+      res.status = jest.fn()
+
       await displayCreateAlertPage(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(res.render).toBeCalledWith('error.njk', {
         url: '/prisoner/ABC123/alerts',
       })
@@ -456,8 +459,11 @@ describe('alert management', () => {
           throw new Error('There has been an error')
         })
 
+        res.status = jest.fn()
+
         await handleCreateAlertForm(req, res)
 
+        expect(res.status).toHaveBeenCalledWith(500)
         expect(res.render).toBeCalledWith('error.njk', {
           url: '/prisoner/ABC123/create-alert',
         })

--- a/backend/tests/amendCaseNoteController.test.js
+++ b/backend/tests/amendCaseNoteController.test.js
@@ -71,8 +71,11 @@ describe('Amendment case note', () => {
     })
     it('should render error page on exception', async () => {
       prisonApi.getDetails.mockRejectedValue(new Error('error'))
+      res.status = jest.fn()
+
       await controller.index(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/prisoner/A12345/case-notes' })
     })
 

--- a/backend/tests/attendanceChanges.test.js
+++ b/backend/tests/attendanceChanges.test.js
@@ -36,6 +36,8 @@ describe('Attendance change router', () => {
         subHeading: '3 November 2020 - AM + PM',
       },
     }
+
+    res.status = jest.fn()
   })
 
   it('should request changes for a given date time range', async () => {
@@ -146,6 +148,7 @@ describe('Attendance change router', () => {
 
     await router(req, res)
 
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(logError).toHaveBeenCalledWith(
       'http://localhost',
       new Error('Network error'),

--- a/backend/tests/attendanceStatistics.test.js
+++ b/backend/tests/attendanceStatistics.test.js
@@ -231,7 +231,7 @@ describe('Attendance reason statistics', () => {
       oauthApi.userRoles.mockReturnValue({})
 
       const { attendanceStatistics } = attendanceStatisticsFactory(oauthApi, prisonApi, whereaboutsApi, jest.fn())
-      const res = { render: jest.fn(), locals: context }
+      const res = { render: jest.fn(), locals: context, status: jest.fn() }
       const req = { query: { agencyId, fromDate, toDate, period } }
 
       await attendanceStatistics(req, res)
@@ -250,7 +250,7 @@ describe('Attendance reason statistics', () => {
 
       const { attendanceStatistics } = attendanceStatisticsFactory(oauthApi, prisonApi, whereaboutsApi, jest.fn())
       const req = { query: { agencyId, fromDate, toDate, period: 'AM_PM' } }
-      const res = { render: jest.fn(), locals: context }
+      const res = { render: jest.fn(), locals: context, status: jest.fn() }
 
       await attendanceStatistics(req, res)
 
@@ -265,7 +265,7 @@ describe('Attendance reason statistics', () => {
     it('should call whereabouts attendance changes api with the correct parameters for AM+PM', async () => {
       const { attendanceStatistics } = attendanceStatisticsFactory(oauthApi, prisonApi, whereaboutsApi, jest.fn())
       const req = { query: { agencyId, fromDate, toDate, period: 'AM_PM' } }
-      const res = { render: jest.fn(), locals: context }
+      const res = { render: jest.fn(), locals: context, status: jest.fn() }
 
       await attendanceStatistics(req, res)
 
@@ -278,7 +278,7 @@ describe('Attendance reason statistics', () => {
     it('should call whereabouts attendance changes api with the correct parameters for AM', async () => {
       const { attendanceStatistics } = attendanceStatisticsFactory(oauthApi, prisonApi, whereaboutsApi, jest.fn())
       const req = { query: { agencyId, fromDate, toDate, period: 'AM' } }
-      const res = { render: jest.fn(), locals: context }
+      const res = { render: jest.fn(), locals: context, status: jest.fn() }
 
       await attendanceStatistics(req, res)
 
@@ -291,7 +291,7 @@ describe('Attendance reason statistics', () => {
     it('should call whereabouts attendance changes api with the correct parameters for PM', async () => {
       const { attendanceStatistics } = attendanceStatisticsFactory(oauthApi, prisonApi, whereaboutsApi, jest.fn())
       const req = { query: { agencyId, fromDate, toDate, period: 'PM' } }
-      const res = { render: jest.fn(), locals: context }
+      const res = { render: jest.fn(), locals: context, status: jest.fn() }
 
       await attendanceStatistics(req, res)
 
@@ -400,10 +400,11 @@ describe('Attendance reason statistics', () => {
       const { attendanceStatistics } = attendanceStatisticsFactory(oauthApi, prisonApi, whereaboutsApi, logError)
 
       const req = { query: { agencyId, date, period } }
-      const res = { render: jest.fn() }
+      const res = { render: jest.fn(), status: jest.fn() }
 
       await attendanceStatistics(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(res.render).toHaveBeenCalledWith('error.njk', {
         url: '/manage-prisoner-whereabouts/attendance-reason-statistics',
       })
@@ -419,10 +420,11 @@ describe('Attendance reason statistics', () => {
       const { attendanceStatistics } = attendanceStatisticsFactory(oauthApi, prisonApi, whereaboutsApi, logError)
 
       const req = { ...mockReq, query: { agencyId, fromDate, period } }
-      const res = { render: jest.fn() }
+      const res = { render: jest.fn(), status: jest.fn() }
 
       await attendanceStatistics(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(logError).toHaveBeenCalledWith(
         '/manage-prisoner-whereabouts/attendance-reason-statistics',
         new Error('something is wrong'),
@@ -627,10 +629,11 @@ describe('Attendance reason statistics', () => {
       )
 
       const req = { query: { agencyId, date, period }, params: { reason: 'AcceptableAbsence' } }
-      const res = { render: jest.fn() }
+      const res = { render: jest.fn(), status: jest.fn() }
 
       await attendanceStatisticsOffendersList(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(res.render).toHaveBeenCalledWith('error.njk', {
         url: '/manage-prisoner-whereabouts/attendance-reason-statistics/reason/AcceptableAbsence',
       })
@@ -650,10 +653,11 @@ describe('Attendance reason statistics', () => {
         logError
       )
       const req = { ...mockReq, query: { agencyId, date, period }, params: { reason: 'AcceptableAbsence' } }
-      const res = { render: jest.fn() }
+      const res = { render: jest.fn(), status: jest.fn() }
 
       await attendanceStatisticsOffendersList(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(logError).toHaveBeenCalledWith(
         '/manage-prisoner-whereabouts/attendance-reason-statistics/reason/',
         new Error('something is wrong'),

--- a/backend/tests/bulkAppointmentsAddDetails.test.js
+++ b/backend/tests/bulkAppointmentsAddDetails.test.js
@@ -46,6 +46,7 @@ describe('Add appointment details controller', () => {
     }
     res = { locals: {} }
     res.render = jest.fn()
+    res.status = jest.fn()
 
     appointmentsService.getAppointmentOptions = jest.fn()
     oauthApi.currentUser = jest.fn()
@@ -86,6 +87,7 @@ describe('Add appointment details controller', () => {
         url: 'http://localhost',
       })
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(logError).toHaveBeenCalledWith('http://localhost', new Error('Network error'), serviceUnavailableMessage)
     })
 

--- a/backend/tests/bulkAppointmentsClashes.test.js
+++ b/backend/tests/bulkAppointmentsClashes.test.js
@@ -245,9 +245,11 @@ describe('appointment clashes', () => {
 
       it('should log an error and render the error page', async () => {
         req.session.data = { ...appointmentDetails }
+        res.status = jest.fn()
 
         await controller.index(req, res)
 
+        expect(res.status).toHaveBeenCalledWith(500)
         expect(res.render).toBeCalledWith('error.njk', { url: '/bulk-appointments/need-to-upload-file' })
       })
     })

--- a/backend/tests/bulkAppointmentsConfirm.test.js
+++ b/backend/tests/bulkAppointmentsConfirm.test.js
@@ -409,8 +409,11 @@ describe('when confirming bulk appointment details', () => {
       })
 
       it('should log an error and render the error page', async () => {
+        res.status = jest.fn()
+
         await controller.post(req, res)
 
+        expect(res.status).toHaveBeenCalledWith(500)
         expect(logError).toBeCalledWith(
           '/bulk-appointments/confirm-appointment/',
           new Error('There has been an error'),

--- a/backend/tests/bulkAppointmentsSlipsController.test.js
+++ b/backend/tests/bulkAppointmentsSlipsController.test.js
@@ -75,6 +75,7 @@ describe('appointment movement slips', () => {
     describe('and there is a small amount of data', () => {
       beforeEach(() => {
         req.session.appointmentSlipsData = { appointmentDetails, prisonersListed }
+        res.status = jest.fn()
       })
 
       it('should call the correct endpoint for the extra required offender information', async () => {
@@ -161,6 +162,7 @@ describe('appointment movement slips', () => {
     describe('and there is a large amount of data', () => {
       beforeEach(() => {
         req.session.appointmentSlipsData = { appointmentDetails, prisonersListed: largePrisonersListed }
+        res.status = jest.fn()
       })
 
       it('should call the correct endpoint the correct amount of times for the extra required offender information', async () => {

--- a/backend/tests/caseNote.test.js
+++ b/backend/tests/caseNote.test.js
@@ -105,9 +105,11 @@ describe('case note management', () => {
       })
 
       const req = { ...mockCreateReq, params: { offenderNo } }
+      res.status = jest.fn()
 
       await displayCreateCaseNotePage(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(res.render).toBeCalledWith('error.njk', { url: '/prisoner/ABC123/case-notes' })
       expect(logError).toBeCalledWith(
         '/add-case-note/',
@@ -189,8 +191,11 @@ describe('case note management', () => {
           throw new Error('There has been an error')
         })
 
+        res.status = jest.fn()
+
         await handleCreateCaseNoteForm(req, res)
 
+        expect(res.status).toHaveBeenCalledWith(500)
         expect(res.render).toBeCalledWith('error.njk', {
           url: '/prisoner/ABC123/add-case-note',
         })

--- a/backend/tests/caseNotesController.test.js
+++ b/backend/tests/caseNotesController.test.js
@@ -71,6 +71,7 @@ describe('Case notes controller', () => {
     res.render = jest.fn()
     res.redirect = jest.fn()
     res.send = jest.fn()
+    res.status = jest.fn()
     nunjucks.render = jest.fn()
     logError = jest.fn()
 
@@ -91,6 +92,7 @@ describe('Case notes controller', () => {
     await controller(reqDefault, res)
 
     expect(logError).toHaveBeenCalledWith('http://localhost', new Error('test'), 'Sorry, the service is unavailable')
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/prisoner/A12345/case-notes' })
   })
 

--- a/backend/tests/cellMove/cellMoveConfirmation.test.js
+++ b/backend/tests/cellMove/cellMoveConfirmation.test.js
@@ -3,7 +3,7 @@ const cellMoveConfirmation = require('../../controllers/cellMove/cellMoveConfirm
 describe('Cell move confirmation', () => {
   let controller
   const req = { params: { offenderNo: 'A12345' }, query: { cellId: 1 }, originalUrl: 'http://localhost' }
-  const res = { locals: {} }
+  const res = { locals: {}, status: jest.fn() }
   const prisonApi = {}
   let logError
 
@@ -36,6 +36,7 @@ describe('Cell move confirmation', () => {
 
     expect(logError).toHaveBeenCalledWith('http://localhost', error, 'Failed to load cell move confirmation page')
 
+    expect(res.status).toHaveBeenCalledWith(400)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       homeUrl: '/prisoner/A12345',
       url: '/prisoner/A12345/cell-move/search-for-cell',

--- a/backend/tests/cellMove/cellNotAvailable.test.js
+++ b/backend/tests/cellMove/cellNotAvailable.test.js
@@ -16,6 +16,7 @@ describe('Cell not available', () => {
     logError = jest.fn()
     res.redirect = jest.fn()
     res.render = jest.fn()
+    res.status = jest.fn()
 
     controller = cellNotAvailable({ prisonApi, logError })
 
@@ -66,6 +67,7 @@ describe('Cell not available', () => {
       error,
       'Failed to load offender details on cell not available page'
     )
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       homeUrl: '/prisoner/A12345',
       url: '/prisoner/A12345/cell-move/search-for-cell',

--- a/backend/tests/cellMove/confirmCellMove.test.js
+++ b/backend/tests/cellMove/confirmCellMove.test.js
@@ -15,7 +15,7 @@ describe('Change cell play back details', () => {
   let logError
   let controller
   const req = { originalUrl: 'http://localhost', params: { offenderNo: 'A12345' }, query: {} }
-  const res = { locals: {} }
+  const res = { locals: {}, status: jest.fn() }
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -312,7 +312,7 @@ describe('Change cell play back details', () => {
       await controller.post(req, res)
 
       expect(logError).toHaveBeenCalledWith('http://localhost', error, 'Failed to make cell move to 223')
-
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(res.render).toHaveBeenCalledWith(
         'error.njk',
         expect.objectContaining({

--- a/backend/tests/cellMove/searchForCell.test.js
+++ b/backend/tests/cellMove/searchForCell.test.js
@@ -88,7 +88,7 @@ describe('select location', () => {
       protocol: 'http',
       get: jest.fn().mockReturnValue('localhost'),
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     prisonApi.getDetails = jest.fn().mockResolvedValue(getDetailsResponse)
     prisonApi.getNonAssociations = jest.fn().mockResolvedValue({ nonAssociations: [] })
@@ -137,6 +137,7 @@ describe('select location', () => {
 
     await controller(req, res)
 
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('Network error'), serviceUnavailableMessage)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       url: '/prisoner/ABC123/cell-move/search-for-cell',

--- a/backend/tests/cellMove/viewCellSharingRiskAssessment.test.js
+++ b/backend/tests/cellMove/viewCellSharingRiskAssessment.test.js
@@ -33,7 +33,7 @@ describe('view CSRA details', () => {
       headers: {},
       get: jest.fn().mockReturnValue('localhost'),
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     prisonApi.getDetails = jest.fn().mockResolvedValue(getDetailsResponse)
     prisonApi.getCsraAssessments = jest.fn().mockResolvedValue([
@@ -94,6 +94,7 @@ describe('view CSRA details', () => {
 
     await controller(req, res)
 
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('Network error'), serviceUnavailableMessage)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       url: '/prisoner/ABC123/cell-move/search-for-cell',

--- a/backend/tests/cellMove/viewNonAssociations.test.js
+++ b/backend/tests/cellMove/viewNonAssociations.test.js
@@ -33,7 +33,7 @@ describe('view non associations', () => {
       protocol: 'http',
       get: jest.fn().mockReturnValue('localhost'),
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     prisonApi.getDetails = jest.fn().mockResolvedValue(getDetailsResponse)
     prisonApi.getNonAssociations = jest.fn().mockResolvedValue({
@@ -139,6 +139,7 @@ describe('view non associations', () => {
 
     await controller(req, res)
 
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('Network error'), serviceUnavailableMessage)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       url: '/prisoner/ABC123/cell-move/non-associations',

--- a/backend/tests/cellMove/viewOffenderDetails.test.js
+++ b/backend/tests/cellMove/viewOffenderDetails.test.js
@@ -40,7 +40,7 @@ describe('view offender details', () => {
       headers: {},
       get: jest.fn().mockReturnValue('localhost'),
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     prisonApi.getDetails = jest.fn().mockResolvedValue(getDetailsResponse)
     prisonApi.getMainOffence = jest.fn().mockResolvedValue([
@@ -64,6 +64,7 @@ describe('view offender details', () => {
 
     await controller(req, res)
 
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('Network error'), serviceUnavailableMessage)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       url: '/prisoner/ABC123/cell-move/search-for-cell',

--- a/backend/tests/changeCaseload.test.js
+++ b/backend/tests/changeCaseload.test.js
@@ -5,7 +5,7 @@ config.app.notmEndpointUrl = '//newNomisEndPointUrl/'
 
 describe('index', () => {
   const prisonApi = {}
-  const mockRes = { render: jest.fn(), redirect: jest.fn(), locals: {} }
+  const mockRes = { render: jest.fn(), redirect: jest.fn(), locals: {}, status: jest.fn() }
   const logError = jest.fn()
 
   let service
@@ -105,6 +105,7 @@ describe('index', () => {
     const res = { ...mockRes }
     await service.index(req, res)
 
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toBeCalledWith('error.njk', {
       url: '/change-caseload',
     })
@@ -169,9 +170,11 @@ describe('post', () => {
     service = changeCaseloadFactory(prisonApi, logError)
 
     req.body = {}
+    res.status = jest.fn()
 
     await service.post(req, res)
 
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toBeCalledWith('error.njk', {
       url: '/change-caseload',
     })

--- a/backend/tests/covidDashboardController.test.js
+++ b/backend/tests/covidDashboardController.test.js
@@ -11,7 +11,7 @@ describe('covid dashboard', () => {
     req = {
       originalUrl: 'http://localhost',
     }
-    res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI' } } }, render: jest.fn() }
+    res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI' } } }, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -66,6 +66,7 @@ describe('covid dashboard', () => {
 
     expect(logError).toHaveBeenCalledWith('http://localhost', error, 'Failed to load dashboard stats')
 
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith(
       'error.njk',
       expect.objectContaining({

--- a/backend/tests/deleteCaseNoteController.test.js
+++ b/backend/tests/deleteCaseNoteController.test.js
@@ -39,6 +39,7 @@ describe('Delete case note', () => {
     res.redirect = jest.fn()
     req.flash = jest.fn()
     req.headers = {}
+    res.status = jest.fn()
 
     req.params = {
       offenderNo: 'A12345',
@@ -70,6 +71,7 @@ describe('Delete case note', () => {
       prisonApi.getDetails.mockRejectedValue(new Error('error'))
       await controller.index(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/prisoner/A12345/case-notes' })
     })
 

--- a/backend/tests/establishmentRoll/currentlyOut.test.js
+++ b/backend/tests/establishmentRoll/currentlyOut.test.js
@@ -7,7 +7,7 @@ describe('Currently out', () => {
   let controller
   const livingUnitId = 1234
   const req = { originalUrl: 'http://localhost', params: { livingUnitId } }
-  const res = { locals: {} }
+  const res = { locals: {}, status: jest.fn() }
   const offenders = [
     {
       offenderNo: 'A1234AA',
@@ -54,6 +54,7 @@ describe('Currently out', () => {
     await controller(req, res)
 
     expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('error'), 'Failed to load currently out page')
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       url: '/establishment-roll/currently-out',
       homeUrl: 'http://localhost:3000/',

--- a/backend/tests/establishmentRoll/enRoute.test.js
+++ b/backend/tests/establishmentRoll/enRoute.test.js
@@ -7,7 +7,7 @@ describe('En route test', () => {
   let controller
   const agencyId = 'LEI'
   const req = { originalUrl: 'http://localhost' }
-  const res = { locals: { user: { activeCaseLoad: { caseLoadId: 'LEI', description: 'Leeds' } } } }
+  const res = { locals: { user: { activeCaseLoad: { caseLoadId: 'LEI', description: 'Leeds' } } }, status: jest.fn() }
   const offenders = [
     {
       offenderNo: 'A1234AA',
@@ -55,6 +55,7 @@ describe('En route test', () => {
     await controller(req, res)
 
     expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('error'), 'Failed to load en route page')
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       url: '/establishment-roll/en-route',
       homeUrl: 'http://localhost:3000/',

--- a/backend/tests/establishmentRoll/inReceptionController.test.js
+++ b/backend/tests/establishmentRoll/inReceptionController.test.js
@@ -33,6 +33,7 @@ describe('In reception controller', () => {
     controller = inReceptionController({ movementsService, logError })
 
     res.render = jest.fn()
+    res.status = jest.fn()
     req = {
       originalUrl: 'http://localhost',
       session: {
@@ -55,6 +56,7 @@ describe('In reception controller', () => {
     await controller(req, res)
 
     expect(logError).toHaveBeenCalledWith('http://localhost', error, 'Error trying to load in-reception page')
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       url: '/establishment-roll/in-reception',
     })

--- a/backend/tests/establishmentRoll/inToday.test.js
+++ b/backend/tests/establishmentRoll/inToday.test.js
@@ -7,7 +7,7 @@ describe('In today', () => {
   let controller
   const agencyId = 'MDI'
   const req = { originalUrl: 'http://localhost' }
-  const res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI', description: 'Leeds' } } } }
+  const res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI', description: 'Leeds' } } }, status: jest.fn() }
   const offenders = [
     {
       offenderNo: 'A1234AA',
@@ -55,6 +55,7 @@ describe('In today', () => {
     await controller(req, res)
 
     expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('error'), 'Failed to load in today page')
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       url: '/establishment-roll/in-today',
       homeUrl: 'http://localhost:3000/',

--- a/backend/tests/establishmentRoll/outToday.test.js
+++ b/backend/tests/establishmentRoll/outToday.test.js
@@ -7,7 +7,7 @@ describe('In today', () => {
   let controller
   const agencyId = 'LEI'
   const req = { originalUrl: 'http://localhost' }
-  const res = { locals: { user: { activeCaseLoad: { caseLoadId: 'LEI', description: 'Leeds' } } } }
+  const res = { locals: { user: { activeCaseLoad: { caseLoadId: 'LEI', description: 'Leeds' } } }, status: jest.fn() }
   const offenders = [
     {
       offenderNo: 'A1234AA',
@@ -48,6 +48,7 @@ describe('In today', () => {
     await controller(req, res)
 
     expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('error'), 'Failed to load out today page')
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       url: '/establishment-roll/out-today',
       homeUrl: 'http://localhost:3000/',

--- a/backend/tests/establishmentRoll/totalCurrentlyOut.test.js
+++ b/backend/tests/establishmentRoll/totalCurrentlyOut.test.js
@@ -7,7 +7,7 @@ describe('Currently out', () => {
   let controller
   const agencyId = 'LEI'
   const req = { originalUrl: 'http://localhost' }
-  const res = { locals: { user: { activeCaseLoad: { caseLoadId: 'LEI', description: 'Leeds' } } } }
+  const res = { locals: { user: { activeCaseLoad: { caseLoadId: 'LEI', description: 'Leeds' } } }, status: jest.fn() }
   const offenders = [
     {
       offenderNo: 'A1234AA',
@@ -56,6 +56,7 @@ describe('Currently out', () => {
       new Error('error'),
       'Failed to load total currently out page'
     )
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith('error.njk', {
       url: '/establishment-roll/total-currently-out',
       homeUrl: 'http://localhost:3000/',

--- a/backend/tests/globalSearch.test.js
+++ b/backend/tests/globalSearch.test.js
@@ -27,6 +27,7 @@ describe('Global search', () => {
       },
       render: jest.fn(),
       redirect: jest.fn(),
+      status: jest.fn(),
     }
 
     logError = jest.fn()

--- a/backend/tests/notInUnitController.test.js
+++ b/backend/tests/notInUnitController.test.js
@@ -12,7 +12,7 @@ describe('not in unit', () => {
     req = {
       originalUrl: 'http://localhost',
     }
-    res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI' } } }, render: jest.fn() }
+    res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI' } } }, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -63,6 +63,7 @@ describe('not in unit', () => {
 
     expect(logError).toHaveBeenCalledWith('http://localhost', error, 'Failed to load not in unit list')
 
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith(
       'error.njk',
       expect.objectContaining({

--- a/backend/tests/prepostAppointments.test.js
+++ b/backend/tests/prepostAppointments.test.js
@@ -201,10 +201,12 @@ describe('Pre post appointments', () => {
       const { index } = prepostAppointmentsFactory({ prisonApi, appointmentsService, logError })
 
       req.flash.mockImplementation(() => [])
+      res.status = jest.fn()
       req.body = body
 
       await index(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(logError).toHaveBeenCalledWith(
         'http://localhost',
         new Error('Appointment details are missing'),

--- a/backend/tests/prisonerAdjudicationDetails.test.js
+++ b/backend/tests/prisonerAdjudicationDetails.test.js
@@ -16,7 +16,7 @@ describe('Prisoner adjudication details', () => {
       originalUrl: 'http://localhost',
       params: { offenderNo, adjudicationNumber },
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -175,6 +175,7 @@ describe('Prisoner adjudication details', () => {
 
       await controller(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('Network error'), serviceUnavailableMessage)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/prisoner/ABC123' })
     })

--- a/backend/tests/prisonerAlerts.test.js
+++ b/backend/tests/prisonerAlerts.test.js
@@ -31,7 +31,7 @@ describe('prisoner alerts', () => {
 
   beforeEach(() => {
     req = { params: { offenderNo }, query: {}, protocol: 'http' }
-    res = { locals: { responseHeaders: { 'total-records': 0 } }, render: jest.fn() }
+    res = { locals: { responseHeaders: { 'total-records': 0 } }, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -232,6 +232,7 @@ describe('prisoner alerts', () => {
         new Error('Problem retrieving alerts'),
         serviceUnavailableMessage
       )
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/prisoner/G3878UK/alerts' })
     })
   })

--- a/backend/tests/prisonerChangeIncentiveLevelDetails.test.js
+++ b/backend/tests/prisonerChangeIncentiveLevelDetails.test.js
@@ -22,7 +22,7 @@ describe('Prisoner change incentive level details', () => {
       params: { offenderNo },
       query: {},
     }
-    res = { locals: { user: { allCaseloads: [] } }, render: jest.fn(), redirect: jest.fn() }
+    res = { locals: { user: { allCaseloads: [] } }, render: jest.fn(), redirect: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -122,6 +122,7 @@ describe('Prisoner change incentive level details', () => {
       it('should render the error template', async () => {
         await controller.index(req, res)
 
+        expect(res.status).toHaveBeenCalledWith(500)
         expect(logError).toHaveBeenCalledWith('http://localhost', new Error('Network error'), serviceUnavailableMessage)
         expect(res.render).toHaveBeenCalledWith('error.njk', { url: `/prisoner/${offenderNo}` })
       })
@@ -232,6 +233,7 @@ describe('Prisoner change incentive level details', () => {
 
         await controller.post(req, res)
 
+        expect(res.status).toHaveBeenCalledWith(500)
         expect(logError).toHaveBeenCalledWith('http://localhost', new Error('Network error'), serviceUnavailableMessage)
         expect(res.render).toHaveBeenCalledWith('error.njk', { url: `/prisoner/${offenderNo}` })
       })

--- a/backend/tests/prisonerDamageObligations.test.js
+++ b/backend/tests/prisonerDamageObligations.test.js
@@ -58,7 +58,7 @@ describe('Prisoner damage obligations', () => {
       originalUrl: 'http://localhost',
       params: { offenderNo },
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -146,6 +146,7 @@ describe('Prisoner damage obligations', () => {
         new Error('Network error'),
         'Damage obligations page - Prisoner finances'
       )
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: `/prisoner/${offenderNo}` })
     })
 
@@ -160,6 +161,7 @@ describe('Prisoner damage obligations', () => {
         new Error('Network error'),
         'Damage obligations page - Prisoner finances'
       )
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: `/prisoner/${offenderNo}` })
     })
   })

--- a/backend/tests/prisonerFullImage.test.js
+++ b/backend/tests/prisonerFullImage.test.js
@@ -16,7 +16,7 @@ describe('prisoner profile full image', () => {
       originalUrl: 'http://localhost',
       params: { offenderNo },
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -65,6 +65,7 @@ describe('prisoner profile full image', () => {
     it('should render the error template', async () => {
       await controller(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(logError).toHaveBeenCalledWith('http://localhost', new Error('Network error'), serviceUnavailableMessage)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: 'http://localhost:3000/' })
     })

--- a/backend/tests/prisonerLocationHistory.test.js
+++ b/backend/tests/prisonerLocationHistory.test.js
@@ -34,7 +34,7 @@ describe('Prisoner location sharing history', () => {
       params: { offenderNo },
       query: { agencyId: 'MDI', locationId: 1, fromDate: '2019-12-31' },
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -278,6 +278,7 @@ describe('Prisoner location sharing history', () => {
 
       await controller(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('Network error'), serviceUnavailableMessage)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/prisoner/ABC123' })
     })
@@ -361,6 +362,7 @@ describe('Prisoner location sharing history', () => {
 
       await controller(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('Not found'), serviceUnavailableMessage)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/prisoner/ABC123' })
     })

--- a/backend/tests/prisonerProfessionalContacts.test.js
+++ b/backend/tests/prisonerProfessionalContacts.test.js
@@ -18,7 +18,7 @@ describe('Prisoner professional contacts', () => {
       originalUrl: 'http://localhost',
       params: { offenderNo },
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -460,6 +460,7 @@ describe('Prisoner professional contacts', () => {
 
       await controller(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('Network error'), serviceUnavailableMessage)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/' })
     })

--- a/backend/tests/prisonerQuickLook.test.js
+++ b/backend/tests/prisonerQuickLook.test.js
@@ -37,7 +37,7 @@ describe('prisoner profile quick look', () => {
         },
       },
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -606,6 +606,7 @@ describe('prisoner profile quick look', () => {
 
       expect(logError).toHaveBeenCalledWith('http://localhost', new Error('Network error'), serviceUnavailableMessage)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: 'http://localhost:3000/' })
+      expect(res.status).toHaveBeenCalledWith(500)
     })
   })
 

--- a/backend/tests/prisonerSchedule.test.js
+++ b/backend/tests/prisonerSchedule.test.js
@@ -19,7 +19,7 @@ describe('Prisoner schedule', () => {
       protocol: 'http',
       get: jest.fn().mockReturnValue('localhost'),
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -313,6 +313,7 @@ describe('Prisoner schedule', () => {
 
       await controller(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('Network error'), serviceUnavailableMessage)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/' })
     })

--- a/backend/tests/prisonerSearch.test.js
+++ b/backend/tests/prisonerSearch.test.js
@@ -31,6 +31,7 @@ describe('Prisoner search', () => {
       },
       render: jest.fn(),
       redirect: jest.fn(),
+      status: jest.fn(),
     }
 
     logError = jest.fn()
@@ -351,6 +352,7 @@ describe('Prisoner search', () => {
 
       await controller.index(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('Network error'), serviceUnavailableMessage)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/', homeUrl: '/' })
     })

--- a/backend/tests/prisonerSentenceAndRelease.test.js
+++ b/backend/tests/prisonerSentenceAndRelease.test.js
@@ -35,6 +35,7 @@ describe('prisoner sentence and release', () => {
     req.originalUrl = '/sentence-and-release'
     req.get = jest.fn()
     req.get.mockReturnValue('localhost')
+    res.status = jest.fn()
 
     prisonerProfileService.getPrisonerProfileData = jest.fn().mockResolvedValue(prisonerProfileData)
     prisonApi.getPrisonerSentenceDetails = jest.fn().mockResolvedValue({
@@ -972,6 +973,7 @@ describe('prisoner sentence and release', () => {
         new Error('Problem retrieving prisoner data'),
         serviceUnavailableMessage
       )
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/prisoner/G3878UK/sentence-and-release' })
     })
   })

--- a/backend/tests/prisonerVisits.test.js
+++ b/backend/tests/prisonerVisits.test.js
@@ -21,7 +21,7 @@ describe('Prisoner visits', () => {
       protocol: 'http',
       get: jest.fn().mockReturnValue('localhost'),
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -262,6 +262,7 @@ describe('Prisoner visits', () => {
 
       await controller(req, res)
 
+      expect(res.status).toHaveBeenCalledWith(500)
       expect(logError).toHaveBeenCalledWith(req.originalUrl, new Error('Network error'), serviceUnavailableMessage)
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/' })
     })

--- a/backend/tests/protectiveIsolationUnitController.test.js
+++ b/backend/tests/protectiveIsolationUnitController.test.js
@@ -14,7 +14,7 @@ describe('protective isolation unit', () => {
     req = {
       originalUrl: 'http://localhost',
     }
-    res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI' } } }, render: jest.fn() }
+    res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI' } } }, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -67,7 +67,7 @@ describe('protective isolation unit', () => {
     await controller(req, res)
 
     expect(logError).toHaveBeenCalledWith('http://localhost', error, 'Failed to load protective isolation list')
-
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith(
       'error.njk',
       expect.objectContaining({

--- a/backend/tests/refusingToShieldController.test.js
+++ b/backend/tests/refusingToShieldController.test.js
@@ -11,7 +11,7 @@ describe('refusing to shield', () => {
     req = {
       originalUrl: 'http://localhost',
     }
-    res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI' } } }, render: jest.fn() }
+    res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI' } } }, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -65,6 +65,7 @@ describe('refusing to shield', () => {
       'Failed to load list of prisoners refusing to shield'
     )
 
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith(
       'error.njk',
       expect.objectContaining({

--- a/backend/tests/retentionReasons.test.js
+++ b/backend/tests/retentionReasons.test.js
@@ -27,7 +27,7 @@ describe('retention reasons', () => {
       params: { offenderNo },
       flash: jest.fn(),
     }
-    res = { locals: {}, render: jest.fn(), redirect: jest.fn() }
+    res = { locals: {}, render: jest.fn(), redirect: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -133,6 +133,7 @@ describe('retention reasons', () => {
       it('should render the error template', async () => {
         await controller.index(req, res)
 
+        expect(res.status).toHaveBeenCalledWith(500)
         expect(logError).toHaveBeenCalledWith('http://localhost', new Error('Network error'), serviceUnavailableMessage)
         expect(res.render).toHaveBeenCalledWith('error.njk', { url: `/offenders/${offenderNo}/retention-reasons` })
       })
@@ -251,6 +252,7 @@ describe('retention reasons', () => {
       it('should render the error template', async () => {
         await controller.post(req, res)
 
+        expect(res.status).toHaveBeenCalledWith(500)
         expect(logError).toHaveBeenCalledWith('http://localhost', new Error('Network error'), serviceUnavailableMessage)
         expect(res.render).toHaveBeenCalledWith('error.njk', { url: `/offenders/${offenderNo}/retention-reasons` })
       })

--- a/backend/tests/reverseCohortingUnitController.test.js
+++ b/backend/tests/reverseCohortingUnitController.test.js
@@ -12,7 +12,7 @@ describe('reverse cohorting unit', () => {
     req = {
       originalUrl: 'http://localhost',
     }
-    res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI' } } }, render: jest.fn() }
+    res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI' } } }, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -67,7 +67,7 @@ describe('reverse cohorting unit', () => {
     await controller(req, res)
 
     expect(logError).toHaveBeenCalledWith('http://localhost', error, 'Failed to load reverse cohorting list')
-
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith(
       'error.njk',
       expect.objectContaining({

--- a/backend/tests/shieldingUnitController.test.js
+++ b/backend/tests/shieldingUnitController.test.js
@@ -14,7 +14,7 @@ describe('shielding unit', () => {
     req = {
       originalUrl: 'http://localhost',
     }
-    res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI' } } }, render: jest.fn() }
+    res = { locals: { user: { activeCaseLoad: { caseLoadId: 'MDI' } } }, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -64,7 +64,7 @@ describe('shielding unit', () => {
     await controller(req, res)
 
     expect(logError).toHaveBeenCalledWith('http://localhost', error, 'Failed to load shielding list')
-
+    expect(res.status).toHaveBeenCalledWith(500)
     expect(res.render).toHaveBeenCalledWith(
       'error.njk',
       expect.objectContaining({

--- a/backend/tests/viewAppointmentsController.test.js
+++ b/backend/tests/viewAppointmentsController.test.js
@@ -23,7 +23,7 @@ describe('View appointments', () => {
         },
       },
     }
-    res = { locals: {}, render: jest.fn() }
+    res = { locals: {}, render: jest.fn(), status: jest.fn() }
 
     logError = jest.fn()
 
@@ -369,6 +369,7 @@ describe('View appointments', () => {
         serviceUnavailableMessage
       )
       expect(res.render).toHaveBeenCalledWith('error.njk', { url: '/appointments' })
+      expect(res.status).toHaveBeenCalledWith(500)
     })
   })
 })

--- a/integration-tests/integration/pageNotFound.spec.js
+++ b/integration-tests/integration/pageNotFound.spec.js
@@ -8,7 +8,7 @@ context('Page not found', () => {
     cy.login()
   })
   it('should render 404 page', () => {
-    cy.visit('/hello')
+    cy.visit('/hello', { failOnStatusCode: false })
     cy.get('h1').should('have.text', 'Page not found')
     cy.get('[role="button"]').click()
 


### PR DESCRIPTION
- This PR simply locates all try catch blocks and ensures the correct http status code is returned. 

_There is a ticket to move to global error handling. This is a quick fix to get insights to work correctly_  