### PR TITLE
NN-3154 Remove covid and bulk appointments link from DSP homepage

### DIFF
--- a/backend/controllers/homepage/homepage.js
+++ b/backend/controllers/homepage/homepage.js
@@ -22,19 +22,11 @@ const getTasks = ({ activeCaseLoadId, locations, staffId, whereaboutsConfig }) =
   },
   {
     id: 'manage-prisoner-whereabouts',
-    heading: 'Manage prisoner whereabouts',
-    description: 'View unlock lists and manage attendance.',
+    heading: 'Prisoner whereabouts',
+    description: 'View unlock lists and COVID units, manage attendance and add bulk appointments.',
     href: '/manage-prisoner-whereabouts',
     roles: null,
     enabled: whereaboutsConfig?.enabled,
-  },
-  {
-    id: 'covid-units',
-    heading: 'View COVID units',
-    description: 'View who in your establishment is in each COVID unit.',
-    href: '/current-covid-units',
-    roles: ['PRISON'],
-    enabled: true,
   },
   {
     id: 'use-of-force',
@@ -78,14 +70,6 @@ const getTasks = ({ activeCaseLoadId, locations, staffId, whereaboutsConfig }) =
     href: '/establishment-roll',
     roles: null,
     enabled: Boolean(locations?.length > 0),
-  },
-  {
-    id: 'bulk-appointments',
-    heading: 'Add bulk appointments',
-    description: 'Upload a file to add appointments for multiple prisoners.',
-    href: '/bulk-appointments/need-to-upload-file',
-    roles: ['BULK_APPOINTMENTS'],
-    enabled: true,
   },
   {
     id: 'manage-key-workers',

--- a/backend/tests/homepageController.test.js
+++ b/backend/tests/homepageController.test.js
@@ -128,29 +128,9 @@ describe('Homepage', () => {
           tasks: [
             {
               id: 'manage-prisoner-whereabouts',
-              heading: 'Manage prisoner whereabouts',
-              description: 'View unlock lists and manage attendance.',
+              heading: 'Prisoner whereabouts',
+              description: 'View unlock lists and COVID units, manage attendance and add bulk appointments.',
               href: '/manage-prisoner-whereabouts',
-            },
-          ],
-        })
-      )
-    })
-
-    it('should render home page with the view covid units task', async () => {
-      oauthApi.userRoles.mockResolvedValue([{ roleCode: 'PRISON' }])
-
-      await controller(req, res)
-
-      expect(res.render).toHaveBeenCalledWith(
-        'homepage/homepage.njk',
-        expect.objectContaining({
-          tasks: [
-            {
-              id: 'covid-units',
-              heading: 'View COVID units',
-              description: 'View who in your establishment is in each COVID unit.',
-              href: '/current-covid-units',
             },
           ],
         })
@@ -257,26 +237,6 @@ describe('Homepage', () => {
               heading: 'Establishment roll check',
               description: 'View the roll broken down by residential unit and see who is arriving and leaving.',
               href: '/establishment-roll',
-            },
-          ],
-        })
-      )
-    })
-
-    it('should render home page with the bulk appointments task', async () => {
-      oauthApi.userRoles.mockResolvedValue([{ roleCode: 'BULK_APPOINTMENTS' }])
-
-      await controller(req, res)
-
-      expect(res.render).toHaveBeenCalledWith(
-        'homepage/homepage.njk',
-        expect.objectContaining({
-          tasks: [
-            {
-              id: 'bulk-appointments',
-              heading: 'Add bulk appointments',
-              description: 'Upload a file to add appointments for multiple prisoners.',
-              href: '/bulk-appointments/need-to-upload-file',
             },
           ],
         })

--- a/integration-tests/integration/homepage/homepage.spec.js
+++ b/integration-tests/integration/homepage/homepage.spec.js
@@ -111,14 +111,6 @@ context('Homepage', () => {
       page.managePrisonerWhereabouts().should('exist')
     })
 
-    it('should show covid units', () => {
-      cy.task('stubUserMeRoles', [{ roleCode: 'PRISON' }])
-
-      const page = homepagePage.goTo()
-
-      page.covidUnits().should('exist')
-    })
-
     it('should show pathfinder', () => {
       cy.task('stubUserMeRoles', [{ roleCode: 'PF_STD_PRISON' }])
 
@@ -133,14 +125,6 @@ context('Homepage', () => {
       const page = homepagePage.goTo()
 
       page.hdcLicences().should('exist')
-    })
-
-    it('should show bulk appointments', () => {
-      cy.task('stubUserMeRoles', [{ roleCode: 'BULK_APPOINTMENTS' }])
-
-      const page = homepagePage.goTo()
-
-      page.bulkAppointments().should('exist')
     })
 
     it('should show manage key workers', () => {

--- a/views/whereabouts/whereaboutsHomepage.njk
+++ b/views/whereabouts/whereaboutsHomepage.njk
@@ -32,3 +32,7 @@
     </div>
   </div>
 {% endblock %}
+
+{% block pageScripts %}
+  <script src="/static/js/card.js"></script>
+{% endblock %}


### PR DESCRIPTION
As they now appear on the new whereabouts homepage.

Also added card to pageScripts section of whereabouts homepage as I missed this from last PR.