### PR TITLE
NN-3197 handle timeouts

### DIFF
--- a/backend/controllers/selectActivityLocation.js
+++ b/backend/controllers/selectActivityLocation.js
@@ -33,6 +33,13 @@ module.exports = ({ prisonApi }) => {
         errors: req.flash('errors'),
       })
     } catch (error) {
+      if (error.code === 'ECONNRESET' || (error.stack && error.stack.toLowerCase().includes('timeout'))) {
+        return res.render('error.njk', {
+          url: res.locals.redirectUrl || req.originalUrl,
+          homeUrl: res.locals.homeUrl,
+        })
+      }
+
       res.locals.redirectUrl = `/manage-prisoner-whereabouts`
       throw error
     }

--- a/views/error.njk
+++ b/views/error.njk
@@ -8,7 +8,7 @@
      {{ govukBreadcrumbs({
          items: [
              {
-                 text: "Home",
+                 text: "Digital Prison Services",
                  href: "/"
              },
              {


### PR DESCRIPTION
The select activity location page uses a very slow query that generally times out on the first few tries. This ticket stops these types of errors polluting our azure logs. 

Longer time we need to investigate if elastic search is a viable solution to this problem. 