### PR TITLE
NN-3175 Update back/cancel link on confirm cell move page

### DIFF
--- a/backend/controllers/cellMove/confirmCellMove.js
+++ b/backend/controllers/cellMove/confirmCellMove.js
@@ -1,6 +1,7 @@
 const { raiseAnalyticsEvent } = require('../../raiseAnalyticsEvent')
 
 const { properCaseName, putLastNameFirst } = require('../../utils')
+const { getBackLinkData } = require('./cellMoveUtils')
 
 const CSWAP = 'C-SWAP'
 
@@ -37,12 +38,12 @@ module.exports = ({ prisonApi, whereaboutsApi, caseNotesApi }) => {
       cellId,
       movingToHeading: isCellSwap ? 'out of their current location' : `to cell ${description}`,
       locationPrefix,
-      selectCellUrl: `/prisoner/${offenderNo}/cell-move/select-cell`,
       cellMoveReasonRadioValues,
       errors: req.flash('errors'),
       formValues: {
         comment,
       },
+      backLink: getBackLinkData(req.headers.referer, offenderNo).backLink,
     })
   }
 

--- a/backend/tests/cellMove/confirmCellMove.test.js
+++ b/backend/tests/cellMove/confirmCellMove.test.js
@@ -14,7 +14,7 @@ describe('Change cell play back details', () => {
 
   let logError
   let controller
-  const req = { originalUrl: 'http://localhost', params: { offenderNo: 'A12345' }, query: {} }
+  const req = { originalUrl: 'http://localhost', params: { offenderNo: 'A12345' }, query: {}, headers: {} }
   const res = { locals: {}, status: jest.fn() }
 
   beforeEach(() => {
@@ -72,6 +72,7 @@ describe('Change cell play back details', () => {
       await controller.index(req, res)
 
       expect(res.render).toHaveBeenCalledWith('cellMove/confirmCellMove.njk', {
+        backLink: '/prisoner/A12345/cell-move/search-for-cell',
         errors: undefined,
         formValues: {
           comment: undefined,
@@ -83,7 +84,6 @@ describe('Change cell play back details', () => {
         locationPrefix: 'MDI-10-19',
         name: 'Bob Doe',
         offenderNo: 'A12345',
-        selectCellUrl: '/prisoner/A12345/cell-move/select-cell',
         showWarning: true,
       })
     })
@@ -102,6 +102,7 @@ describe('Change cell play back details', () => {
       await controller.index(req, res)
 
       expect(res.render).toHaveBeenCalledWith('cellMove/confirmCellMove.njk', {
+        backLink: '/prisoner/A12345/cell-move/search-for-cell',
         breadcrumbPrisonerName: 'Doe, Bob',
         cellId: 'C-SWAP',
         cellMoveReasonRadioValues: undefined,
@@ -113,7 +114,6 @@ describe('Change cell play back details', () => {
         locationPrefix: undefined,
         name: 'Bob Doe',
         offenderNo: 'A12345',
-        selectCellUrl: '/prisoner/A12345/cell-move/select-cell',
         showWarning: false,
       })
     })
@@ -195,6 +195,19 @@ describe('Change cell play back details', () => {
           formValues: {
             comment: 'Hello',
           },
+        })
+      )
+    })
+
+    it('sets the back link when referer data is present', async () => {
+      req.headers = { referer: `/prisoner/A12345/cell-move/select-cell` }
+
+      await controller.index(req, res)
+
+      expect(res.render).toHaveBeenCalledWith(
+        'cellMove/confirmCellMove.njk',
+        expect.objectContaining({
+          backLink: `/prisoner/A12345/cell-move/select-cell`,
         })
       )
     })

--- a/integration-tests/integration/cellMove/confirmCellMove.spec.js
+++ b/integration-tests/integration/cellMove/confirmCellMove.spec.js
@@ -70,12 +70,13 @@ context('A user can confirm the cell move', () => {
     cy.location('pathname').should('eq', `/prisoner/${offenderNo}/cell-move/confirmation`)
   })
 
-  it('should navigate back to select cell', () => {
+  it('should navigate back to search for cell', () => {
     const page = ConfirmCellMovePage.goTo('A12345', 1, 'Bob Doe', 'MDI-1-1')
 
-    page.backToSelectCellLink().click()
+    page.backLink().contains('Cancel')
+    page.backLink().click()
 
-    cy.location('pathname').should('eq', '/prisoner/A12345/cell-move/select-cell')
+    cy.location('pathname').should('eq', '/prisoner/A12345/cell-move/search-for-cell')
   })
 
   it('should not mention c-swap', () => {

--- a/integration-tests/pages/cellMove/confirmCellMovePage.js
+++ b/integration-tests/pages/cellMove/confirmCellMovePage.js
@@ -2,7 +2,7 @@ const page = require('../page')
 
 const confirmCellMovePage = (name, cell) =>
   page(`You are moving ${name} ${cell === 'swap' ? 'out of their current location' : `to cell ${cell}`}`, {
-    backToSelectCellLink: () => cy.get('[data-qa="back-to-select-cell"]'),
+    backLink: () => cy.get('[data-test="back-link"]'),
     warning: () => cy.get('.govuk-inset-text'),
     form: () => ({
       submitButton: () => cy.get('button[type="submit"]'),

--- a/views/cellMove/confirmCellMove.njk
+++ b/views/cellMove/confirmCellMove.njk
@@ -89,7 +89,7 @@
             </form>
 
             <p class="govuk-body govuk-!-margin-top-4">
-                <a href="{{ selectCellUrl }}" class="govuk-link" data-qa="back-to-select-cell">Select another cell</a>
+                <a href="{{ backLink }}" class="govuk-link" data-test="back-link">Cancel</a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
Link text changed to cancel as there is now multiple entry points to this page. Returns to search for cell page by default, but should use the referring url, if available. 

![Screenshot 2021-03-15 at 11 07 41](https://user-images.githubusercontent.com/1067537/111144253-c0166a00-857e-11eb-85d9-a7def6659fa8.png)
