### PR TITLE
NN-3149 Update content on cell move consider risks page

### DIFF
--- a/backend/controllers/cellMove/considerRisks.js
+++ b/backend/controllers/cellMove/considerRisks.js
@@ -32,6 +32,7 @@ module.exports = ({ prisonApi, raiseAnalyticsEvent }) => {
         prisonApi.getInmatesAtLocation(res.locals, cellId, {}),
       ])
 
+      const hasOccupants = occupants.length > 0
       const currentOccupantsOffenderNos = occupants.map(occupant => occupant.offenderNo)
       const currentOccupantsDetails = occupants && (await getOccupantsDetails(res.locals, currentOccupantsOffenderNos))
 
@@ -57,7 +58,7 @@ module.exports = ({ prisonApi, raiseAnalyticsEvent }) => {
         .filter(currentOccupant => currentOccupant.csra)
         .map(currentOccupant => currentOccupant.csra)
 
-      const showOffendersNamesWithCsra = offendersCsraValues.includes('High')
+      const showOffendersNamesWithCsra = hasOccupants && offendersCsraValues.includes('High')
 
       const currentOccupantsFormattedNames = currentOccupantsDetails.map(({ firstName, lastName }) =>
         formatName(firstName, lastName)
@@ -157,7 +158,11 @@ module.exports = ({ prisonApi, raiseAnalyticsEvent }) => {
         profileUrl,
         selectCellUrl: `${profileUrl}/cell-move/select-cell`,
         showOffendersNamesWithCsra,
-        stringListOfCurrentOccupantsNames: createStringFromList(currentOccupantsFormattedNames),
+        confirmationQuestionLabel: hasOccupants
+          ? `Are you sure you want to move ${currentOffenderName} into a cell with ${createStringFromList(
+              currentOccupantsFormattedNames
+            )}?`
+          : 'Are you sure you want to select this cell?',
         offendersFormattedNamesWithCsra,
         nonAssociations: nonAssociationsWithinLocation.map(nonAssociation => ({
           name: `${putLastNameFirst(

--- a/backend/tests/cellMove/considerRisks.test.js
+++ b/backend/tests/cellMove/considerRisks.test.js
@@ -432,6 +432,8 @@ describe('move validation', () => {
 
     expect(res.render).toHaveBeenCalledWith('cellMove/considerRisks.njk', {
       categoryWarning: 'a Cat A rating and Occupant One is a Cat not entered and Occupant Two is a Cat B',
+      confirmationQuestionLabel:
+        'Are you sure you want to move Test User into a cell with Occupant One and Occupant Two?',
       currentOccupantsWithFormattedActiveAlerts: [
         {
           alerts: [
@@ -510,7 +512,6 @@ describe('move validation', () => {
       selectCellUrl: '/prisoner/ABC123/cell-move/select-cell',
       showOffendersNamesWithCsra: true,
       showRisks: true,
-      stringListOfCurrentOccupantsNames: 'Occupant One and Occupant Two',
     })
   })
 
@@ -606,15 +607,18 @@ describe('move validation', () => {
       )
     })
 
-    it('Does not pass category warning if no inmates', async () => {
+    it('Passes the correct conditional data to the template when there are no inmates at the location', async () => {
       prisonApi.getDetails.mockResolvedValueOnce({ ...getCurrentOffenderDetailsResponse, csra: 'Standard' })
       prisonApi.getInmatesAtLocation.mockResolvedValue([])
+
       await controller.index(req, res)
 
       expect(res.render).toHaveBeenCalledWith(
         'cellMove/considerRisks.njk',
         expect.objectContaining({
           categoryWarning: false,
+          confirmationQuestionLabel: 'Are you sure you want to select this cell?',
+          showOffendersNamesWithCsra: false,
           showRisks: false,
         })
       )

--- a/integration-tests/integration/cellMove/considerRisks.spec.js
+++ b/integration-tests/integration/cellMove/considerRisks.spec.js
@@ -321,6 +321,10 @@ context('A user can see conflicts in cell', () => {
       expect($dates.get(6)).to.contain('Date added: 20 August 2019')
       expect($dates.get(7)).to.contain('Date added: 20 August 2020')
     })
+    page
+      .form()
+      .confirmationInput()
+      .contains('Are you sure you want to move Test User into a cell with Occupant User?')
   })
 
   it('should show error when nothing is selected', () => {
@@ -382,5 +386,22 @@ context('A user can see conflicts in cell', () => {
     cy.visit(`/prisoner/${offenderNo}/cell-move/consider-risks?cellId=1`)
 
     ConfirmCellMovePage.verifyOnPage('Bob Doe', 'MDI-1-1')
+  })
+
+  describe('when there are no inmates at the location', () => {
+    beforeEach(() => {
+      cy.task('stubInmatesAtLocation', {
+        inmates: [],
+      })
+    })
+
+    it('should not show CSRA messages and have the correct confirmation label', () => {
+      const page = ConsiderRisksPage.goTo(offenderNo, 1)
+      page.csraMessages().should('not.exist')
+      page
+        .form()
+        .confirmationInput()
+        .contains('Are you sure you want to select this cell?')
+    })
   })
 })

--- a/integration-tests/pages/cellMove/considerRisksPage.js
+++ b/integration-tests/pages/cellMove/considerRisksPage.js
@@ -14,6 +14,7 @@ const considerRisksPage = () =>
     categoryWarning: () => cy.get("[data-test='category-warning']"),
     errorSummary: () => cy.get('.govuk-error-summary'),
     form: () => ({
+      confirmationInput: () => cy.get("[data-test='confirmation-input']"),
       confirmationYes: () => cy.get('#confirmation'),
       confirmationNo: () => cy.get('#confirmation-2'),
       submitButton: () => cy.get('button[type="submit"]'),

--- a/views/cellMove/considerRisks.njk
+++ b/views/cellMove/considerRisks.njk
@@ -183,8 +183,9 @@
           name: "confirmation",
           errorMessage: errors | findError('confirmation'),
           fieldset: {
+              attributes: { 'data-test': 'confirmation-input' },
               legend: {
-                  text: "Are you sure you want to move " + currentOffenderName + " into a cell with " + stringListOfCurrentOccupantsNames +"?",
+                  text: confirmationQuestionLabel,
                   classes: "govuk-fieldset__legend--s"
               }
           },


### PR DESCRIPTION
When there are no inmates in the location you are moving a prisoner too (usually single occupancy):
- Do not display CSRA info
- Confirmation label should not mention any prisoner names and just say, **Are you sure you want to select this cell?**

![image](https://user-images.githubusercontent.com/1067537/111508360-88a4ea80-8743-11eb-978a-4618030c35b5.png)
