### PR TITLE
NN-3187: Do not show temporary cell names when selecting cell

### DIFF
--- a/backend/controllers/cellMove/selectCell.js
+++ b/backend/controllers/cellMove/selectCell.js
@@ -1,6 +1,6 @@
 const moment = require('moment')
 const { alertFlagLabels, cellMoveAlertCodes } = require('../../shared/alertFlagValues')
-const { putLastNameFirst, hasLength, groupBy, properCaseName, formatName } = require('../../utils')
+const { putLastNameFirst, hasLength, groupBy, properCaseName, formatName, formatLocation } = require('../../utils')
 const {
   userHasAccess,
   getNonAssocationsInEstablishment,
@@ -186,6 +186,14 @@ module.exports = ({ oauthApi, prisonApi, whereaboutsApi }) => async (req, res) =
 
     const numberOfNonAssociations = getNonAssocationsInEstablishment(nonAssociations).length
 
+    const prisonerDetailsWithFormattedLocation = {
+      ...prisonerDetails,
+      assignedLivingUnit: {
+        ...prisonerDetails.assignedLivingUnit,
+        description: formatLocation(prisonerDetails?.assignedLivingUnit?.description),
+      },
+    }
+
     return res.render('cellMove/selectCell.njk', {
       formValues: {
         location,
@@ -209,7 +217,7 @@ module.exports = ({ oauthApi, prisonApi, whereaboutsApi }) => async (req, res) =
       locations: renderLocationOptions(locationsData),
       subLocations,
       cellAttributes,
-      prisonerDetails,
+      prisonerDetails: prisonerDetailsWithFormattedLocation,
       offenderNo,
       nonAssociationLink: `/prisoner/${offenderNo}/cell-move/non-associations`,
       offenderDetailsUrl: `/prisoner/${offenderNo}/cell-move/offender-details`,

--- a/backend/tests/cellMove/selectCell.test.js
+++ b/backend/tests/cellMove/selectCell.test.js
@@ -194,6 +194,7 @@ describe('Select a cell', () => {
             firstName: 'John',
             lastName: 'Doe',
             offenderNo: 'A12345',
+            assignedLivingUnit: {},
           },
         })
       )
@@ -860,6 +861,42 @@ describe('Select a cell', () => {
         'cellMove/selectCell.njk',
         expect.objectContaining({
           showNonAssociationWarning: false,
+        })
+      )
+    })
+  })
+
+  describe('Current location is not a cell', () => {
+    it('shows the CSWAP description as the location', async () => {
+      prisonApi.userCaseLoads = jest.fn().mockResolvedValue([{ caseLoadId: 'MDI' }])
+      prisonApi.getDetails = jest.fn().mockResolvedValue({
+        firstName: 'John',
+        lastName: 'Doe',
+        offenderNo: someOffenderNumber,
+        bookingId: someBookingId,
+        agencyId: 'MDI',
+        alerts: [],
+        assignedLivingUnit: {
+          description: 'CSWAP',
+        },
+      })
+
+      await controller(req, res)
+
+      expect(res.render).toHaveBeenCalledWith(
+        'cellMove/selectCell.njk',
+        expect.objectContaining({
+          prisonerDetails: {
+            agencyId: 'MDI',
+            alerts: [],
+            bookingId: -10,
+            firstName: 'John',
+            lastName: 'Doe',
+            offenderNo: 'A12345',
+            assignedLivingUnit: {
+              description: 'No cell allocated',
+            },
+          },
         })
       )
     })


### PR DESCRIPTION
Do not show temporary cell codes in select-cell - show the description