### PR TITLE
NN-3238 Hide comment input on confirm move page when cswap/create space

### DIFF
--- a/backend/controllers/cellMove/confirmCellMove.js
+++ b/backend/controllers/cellMove/confirmCellMove.js
@@ -44,6 +44,7 @@ module.exports = ({ prisonApi, whereaboutsApi, caseNotesApi }) => {
         comment,
       },
       backLink: getBackLinkData(req.headers.referer, offenderNo).backLink,
+      showCommentInput: !isCellSwap,
     })
   }
 

--- a/backend/tests/cellMove/confirmCellMove.test.js
+++ b/backend/tests/cellMove/confirmCellMove.test.js
@@ -84,6 +84,7 @@ describe('Change cell play back details', () => {
         locationPrefix: 'MDI-10-19',
         name: 'Bob Doe',
         offenderNo: 'A12345',
+        showCommentInput: true,
         showWarning: true,
       })
     })
@@ -114,6 +115,7 @@ describe('Change cell play back details', () => {
         locationPrefix: undefined,
         name: 'Bob Doe',
         offenderNo: 'A12345',
+        showCommentInput: false,
         showWarning: false,
       })
     })

--- a/integration-tests/integration/cellMove/confirmCellMove.spec.js
+++ b/integration-tests/integration/cellMove/confirmCellMove.spec.js
@@ -79,10 +79,20 @@ context('A user can confirm the cell move', () => {
     cy.location('pathname').should('eq', '/prisoner/A12345/cell-move/search-for-cell')
   })
 
-  it('should not mention c-swap', () => {
+  it('should not mention c-swap or show form inputs', () => {
     const page = ConfirmCellMovePage.goTo('A12345', 'C-SWAP', 'Bob Doe', 'swap')
 
     page.warning().should('not.exist')
+
+    page
+      .form()
+      .reason()
+      .should('not.exist')
+
+    page
+      .form()
+      .comment()
+      .should('not.exist')
 
     page
       .form()

--- a/views/cellMove/confirmCellMove.njk
+++ b/views/cellMove/confirmCellMove.njk
@@ -69,21 +69,23 @@
                     }) }}
                 {% endif %}
 
-                {{ govukTextarea({
-                    name: "comment",
-                    id: "comment",
-                    maxlength: 4000,
-                    value: formValues.comment,
-                    errorMessage: errors | findError('comment'),
-                    classes: 'govuk-!-width-one-half',
-                    hint: {
-                        text: 'This will be used to add a case note.'
-                    },
-                    label: {
-                        text: "What happened?",
-                        classes: "govuk-!-font-weight-bold"
-                    }
-                }) }}
+                {% if showCommentInput %}
+                    {{ govukTextarea({
+                        name: "comment",
+                        id: "comment",
+                        maxlength: 4000,
+                        value: formValues.comment,
+                        errorMessage: errors | findError('comment'),
+                        classes: 'govuk-!-width-one-half',
+                        hint: {
+                            text: 'This will be used to add a case note.'
+                        },
+                        label: {
+                            text: "What happened?",
+                            classes: "govuk-!-font-weight-bold"
+                        }
+                    }) }}
+                {% endif %}
 
                 {{ govukButton({ text: "Confirm move", type: "submit" }) }}
             </form>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1067537/111618352-2c41d980-87dc-11eb-8862-0d6c7ed7bd03.png)
