### PR TITLE
DCS-983 Send court ids when creating a BVL booking

### DIFF
--- a/backend/api/whereaboutsApi.js
+++ b/backend/api/whereaboutsApi.js
@@ -68,7 +68,7 @@ const whereaboutsApiFactory = client => {
   const getAgencyGroupLocations = (context, agencyId, groupName) =>
     get(context, `/locations/groups/${agencyId}/${groupName}`)
 
-  const getCourtLocations = context => get(context, '/court/all-courts')
+  const getCourtLocations = context => get(context, '/court/courts')
 
   const addVideoLinkBooking = (context, body) => post(context, '/court/video-link-bookings', body)
 

--- a/backend/controllers/appointments/prepostAppoinments.js
+++ b/backend/controllers/appointments/prepostAppoinments.js
@@ -250,7 +250,7 @@ const prepostAppointmentsFactory = ({
       preAppointmentDuration,
       preAppointmentLocation,
       postAppointmentLocation,
-      court,
+      court: courtId,
       otherCourt,
       otherCourtForm,
     } = req.body
@@ -273,7 +273,7 @@ const prepostAppointmentsFactory = ({
         postAppointment,
         preAppointmentLocation,
         postAppointmentLocation,
-        court,
+        court: courtId,
         otherCourt,
         otherCourtForm,
       })
@@ -286,7 +286,7 @@ const prepostAppointmentsFactory = ({
       })
 
       const courts = await getCourts(res.locals)
-      const courtName = otherCourt || courts[court]
+      const courtName = otherCourt || courts[courtId]
 
       const preDetails = (preAppointment === 'yes' &&
         toPreAppointment({
@@ -324,7 +324,7 @@ const prepostAppointmentsFactory = ({
               preAppointmentDuration,
               preAppointmentLocation,
               postAppointmentLocation,
-              court,
+              court: courtId,
             },
             errors,
           })
@@ -342,7 +342,7 @@ const prepostAppointmentsFactory = ({
             preAppointmentDuration,
             preAppointmentLocation: preAppointmentLocation && Number(preAppointmentLocation),
             postAppointmentLocation: postAppointmentLocation && Number(postAppointmentLocation),
-            court,
+            court: courtId,
           },
           errors,
           date,
@@ -356,7 +356,7 @@ const prepostAppointmentsFactory = ({
         })
       }
 
-      if (court === 'other') {
+      if (courtId === 'other') {
         return res.render('enterCustomCourt.njk', {
           cancel: `/offenders/${offenderNo}/prepost-appointments`,
           formValues: {
@@ -366,7 +366,7 @@ const prepostAppointmentsFactory = ({
             preAppointmentDuration,
             preAppointmentLocation: preAppointmentLocation && Number(preAppointmentLocation),
             postAppointmentLocation: postAppointmentLocation && Number(postAppointmentLocation),
-            court,
+            court: courtId,
           },
           errors,
           date,
@@ -379,7 +379,7 @@ const prepostAppointmentsFactory = ({
           ...appointmentDetails,
           // Pass court name if 'other' as it means free text, else send court ID
           courtName: otherCourt ? courtName : undefined,
-          courtId: !otherCourt ? court : undefined,
+          courtId: !otherCourt ? courtId : undefined,
         },
         preAppointment === 'yes' && preDetails,
         postAppointment === 'yes' && postDetails

--- a/integration-tests/integration/appointments/addAppointment.spec.js
+++ b/integration-tests/integration/appointments/addAppointment.spec.js
@@ -187,7 +187,7 @@ context('A user can add an appointment', () => {
     cy.task('getBookingRequest').then(request => {
       expect(request).to.deep.equal({
         bookingId: 14,
-        court: 'Leeds',
+        courtId: 'LDS',
         comment: 'Test comment',
         madeByTheCourt: false,
         pre: {

--- a/integration-tests/mockApis/whereabouts.js
+++ b/integration-tests/mockApis/whereabouts.js
@@ -68,16 +68,18 @@ module.exports = {
     return stubFor({
       request: {
         method: 'GET',
-        url: '/whereabouts/court/all-courts',
+        url: '/whereabouts/court/courts',
       },
       response: {
         status,
         headers: {
           'Content-Type': 'application/json;charset=UTF-8',
         },
-        jsonBody: locations || {
-          courtLocations: ['London', 'Sheffield', 'Leeds'],
-        },
+        jsonBody: locations || [
+          { id: 'LDN', name: 'London' },
+          { id: 'SHF', name: 'Sheffield' },
+          { id: 'LDS', name: 'Leeds' },
+        ],
       },
     })
   },

--- a/integration-tests/plugins/index.js
+++ b/integration-tests/plugins/index.js
@@ -75,7 +75,7 @@ module.exports = on => {
       Promise.all([prisonApi.stubProgEventsAtLocation(caseload, locationId, timeSlot, date, activities)]),
 
     stubAttendanceChanges: response => Promise.all([whereabouts.stubAttendanceChanges(response)]),
-    stubCourts: courts => Promise.all([whereabouts.stubCourtLocations(courts)]),
+    stubCourts: whereabouts.stubCourtLocations,
     stubGroups: caseload => whereabouts.stubGroups(caseload),
     stubAddVideoLinkBooking: () => whereabouts.stubAddVideoLinkBooking(),
     getBookingRequest: () => whereabouts.getBookingRequest(),


### PR DESCRIPTION
We now send will send court ids when creating new bookings when we can tie this to a specific known court

We still will need to send the court name through if a user selects an 'other' court. These other courts won't appear in the BVL booking list