### PR TITLE
DCS-1007 Prevent users from specifying duration of pre/post appointments 

### DIFF
--- a/backend/controllers/appointments/prepostAppoinments.js
+++ b/backend/controllers/appointments/prepostAppoinments.js
@@ -7,6 +7,8 @@ const {
 
 const { properCaseName } = require('../../utils')
 
+const APPOINTMENT_DURATION_MINS = 15
+
 const unpackAppointmentDetails = req => {
   const appointmentDetails = req.flash('appointmentDetails')
   if (!appointmentDetails || !appointmentDetails.length) throw new Error('Appointment details are missing')
@@ -166,8 +168,6 @@ const prepostAppointmentsFactory = ({
         formValues: {
           postAppointment: (postAppointment && postAppointment.required) || 'yes',
           preAppointment: (preAppointment && preAppointment.required) || 'yes',
-          preAppointmentDuration: (preAppointment && preAppointment.duration) || '20',
-          postAppointmentDuration: (postAppointment && postAppointment.duration) || '20',
           preAppointmentLocation: preAppointment && Number(preAppointment.locationId),
           postAppointmentLocation: postAppointment && Number(postAppointment.locationId),
         },
@@ -217,25 +217,23 @@ const prepostAppointmentsFactory = ({
     })
   }
 
-  const toPreAppointment = ({ startTime, preAppointmentDuration, preAppointmentLocation }) => {
-    const preStartTime = moment(startTime, DATE_TIME_FORMAT_SPEC).subtract(Number(preAppointmentDuration), 'minutes')
-    const preEndTime = moment(preStartTime, DATE_TIME_FORMAT_SPEC).add(Number(preAppointmentDuration), 'minutes')
+  const toPreAppointment = ({ startTime, preAppointmentLocation }) => {
+    const preStartTime = moment(startTime, DATE_TIME_FORMAT_SPEC).subtract(APPOINTMENT_DURATION_MINS, 'minutes')
+    const preEndTime = moment(preStartTime, DATE_TIME_FORMAT_SPEC).add(APPOINTMENT_DURATION_MINS, 'minutes')
     return {
       startTime: preStartTime.format(DATE_TIME_FORMAT_SPEC),
       endTime: preEndTime.format(DATE_TIME_FORMAT_SPEC),
       locationId: Number(preAppointmentLocation),
-      duration: preAppointmentDuration,
     }
   }
 
-  const toPostAppointment = ({ endTime, postAppointmentDuration, postAppointmentLocation }) => {
-    const postEndTime = moment(endTime, DATE_TIME_FORMAT_SPEC).add(Number(postAppointmentDuration), 'minutes')
+  const toPostAppointment = ({ endTime, postAppointmentLocation }) => {
+    const postEndTime = moment(endTime, DATE_TIME_FORMAT_SPEC).add(APPOINTMENT_DURATION_MINS, 'minutes')
 
     return {
       startTime: endTime,
       endTime: postEndTime.format(DATE_TIME_FORMAT_SPEC),
       locationId: Number(postAppointmentLocation),
-      duration: postAppointmentDuration,
     }
   }
 
@@ -246,8 +244,6 @@ const prepostAppointmentsFactory = ({
     const {
       postAppointment,
       preAppointment,
-      postAppointmentDuration,
-      preAppointmentDuration,
       preAppointmentLocation,
       postAppointmentLocation,
       court: courtId,
@@ -292,14 +288,12 @@ const prepostAppointmentsFactory = ({
         toPreAppointment({
           startTime,
           preAppointmentLocation,
-          preAppointmentDuration,
         })) || { required: 'no' }
 
       const postDetails = (postAppointment === 'yes' &&
         toPostAppointment({
           endTime,
           postAppointmentLocation,
-          postAppointmentDuration,
         })) || { required: 'no' }
 
       packAppointmentDetails(req, {
@@ -320,8 +314,6 @@ const prepostAppointmentsFactory = ({
             formValues: {
               postAppointment,
               preAppointment,
-              postAppointmentDuration,
-              preAppointmentDuration,
               preAppointmentLocation,
               postAppointmentLocation,
               court: courtId,
@@ -338,8 +330,6 @@ const prepostAppointmentsFactory = ({
           formValues: {
             postAppointment,
             preAppointment,
-            postAppointmentDuration,
-            preAppointmentDuration,
             preAppointmentLocation: preAppointmentLocation && Number(preAppointmentLocation),
             postAppointmentLocation: postAppointmentLocation && Number(postAppointmentLocation),
             court: courtId,
@@ -362,8 +352,6 @@ const prepostAppointmentsFactory = ({
           formValues: {
             postAppointment,
             preAppointment,
-            postAppointmentDuration,
-            preAppointmentDuration,
             preAppointmentLocation: preAppointmentLocation && Number(preAppointmentLocation),
             postAppointmentLocation: postAppointmentLocation && Number(postAppointmentLocation),
             court: courtId,
@@ -393,14 +381,14 @@ const prepostAppointmentsFactory = ({
       const preAppointmentInfo =
         preAppointment === 'yes'
           ? `${locationEvents.preAppointment.locationName}, ${Time(
-              moment(startTime, DATE_TIME_FORMAT_SPEC).subtract(preAppointmentDuration, 'minutes')
+              moment(startTime, DATE_TIME_FORMAT_SPEC).subtract(APPOINTMENT_DURATION_MINS, 'minutes')
             )} to ${Time(startTime)}`
           : 'None requested'
 
       const postAppointmentInfo =
         postAppointment === 'yes'
           ? `${locationEvents.postAppointment.locationName}, ${Time(endTime)} to ${Time(
-              moment(endTime, DATE_TIME_FORMAT_SPEC).add(postAppointmentDuration, 'minutes')
+              moment(endTime, DATE_TIME_FORMAT_SPEC).add(APPOINTMENT_DURATION_MINS, 'minutes')
             )}`
           : 'None requested'
 

--- a/backend/tests/prepostAppointments.test.js
+++ b/backend/tests/prepostAppointments.test.js
@@ -85,7 +85,6 @@ describe('Pre post appointments', () => {
     body = {
       postAppointment: 'yes',
       preAppointment: 'no',
-      postAppointmentDuration: '60',
       court: 'LDNCOURT-1',
     }
   })
@@ -168,8 +167,6 @@ describe('Pre post appointments', () => {
           formValues: {
             postAppointment: 'yes',
             preAppointment: 'yes',
-            postAppointmentDuration: '20',
-            preAppointmentDuration: '20',
           },
         })
       )
@@ -426,7 +423,6 @@ describe('Pre post appointments', () => {
         preAppointment: 'yes',
         preAppointmentLocation: 2,
         postAppointment: 'yes',
-        postAppointmentDuration: '60',
         court: 'london',
       }
 
@@ -439,7 +435,6 @@ describe('Pre post appointments', () => {
             preAppointment: 'yes',
             preAppointmentLocation: 2,
             postAppointment: 'yes',
-            postAppointmentDuration: '60',
             court: 'london',
           },
         })
@@ -658,7 +653,7 @@ describe('Pre post appointments', () => {
             },
             post: {
               startTime: '2017-10-10T14:00',
-              endTime: '2017-10-10T15:00:00',
+              endTime: '2017-10-10T14:15:00',
               locationId: 3,
             },
           }
@@ -698,7 +693,7 @@ describe('Pre post appointments', () => {
             },
             post: {
               startTime: '2017-10-10T14:00',
-              endTime: '2017-10-10T15:00:00',
+              endTime: '2017-10-10T14:15:00',
               locationId: 3,
             },
           }
@@ -758,8 +753,6 @@ describe('Pre post appointments', () => {
           preAppointment: 'yes',
           preAppointmentLocation: 1,
           postAppointmentLocation: 2,
-          preAppointmentDuration: 15,
-          postAppointmentDuration: 15,
           court: 'london',
         }
 
@@ -772,13 +765,11 @@ describe('Pre post appointments', () => {
               endTime: '2017-10-10T11:00:00',
               locationId: 1,
               startTime: '2017-10-10T10:45:00',
-              duration: 15,
             },
             postAppointment: {
               endTime: '2017-10-10T14:15:00',
               locationId: 2,
               startTime: '2017-10-10T14:00',
-              duration: 15,
             },
           })
         )

--- a/backend/tests/prepostAppointments.test.js
+++ b/backend/tests/prepostAppointments.test.js
@@ -610,8 +610,6 @@ describe('Pre post appointments', () => {
         req.body = {
           postAppointment: 'yes',
           preAppointment: 'yes',
-          postAppointmentDuration: '60',
-          preAppointmentDuration: '15',
           preAppointmentLocation: '2',
           postAppointmentLocation: '3',
           court: 'LDNCOURT-1',

--- a/integration-tests/integration/appointments/addAppointment.spec.js
+++ b/integration-tests/integration/appointments/addAppointment.spec.js
@@ -176,7 +176,6 @@ context('A user can add an appointment', () => {
     const prePostForm = prePostAppointmentsPage.form()
 
     prePostForm.preAppointmentLocation().select('1')
-    prePostForm.preAppointmentDuration().select('20')
     prePostForm.postAppointmentNo().click()
     prePostForm.court().select('Leeds')
     prePostForm.submitButton().click()
@@ -192,7 +191,7 @@ context('A user can add an appointment', () => {
         madeByTheCourt: false,
         pre: {
           locationId: 1,
-          startTime: moment().format(`YYYY-MM-DD[T22:35:00]`),
+          startTime: moment().format(`YYYY-MM-DD[T22:40:00]`),
           endTime: moment().format(`YYYY-MM-DD[T22:55:00]`),
         },
         main: {
@@ -254,7 +253,6 @@ context('A user can add an appointment', () => {
     const prePostForm = prePostAppointmentsPage.form()
 
     prePostForm.preAppointmentLocation().select('1')
-    prePostForm.preAppointmentDuration().select('20')
     prePostForm.postAppointmentNo().click()
     prePostForm.court().select('Other')
     prePostForm.submitButton().click()
@@ -276,7 +274,7 @@ context('A user can add an appointment', () => {
         madeByTheCourt: false,
         pre: {
           locationId: 1,
-          startTime: moment().format(`YYYY-MM-DD[T22:35:00]`),
+          startTime: moment().format(`YYYY-MM-DD[T22:40:00]`),
           endTime: moment().format(`YYYY-MM-DD[T22:55:00]`),
         },
         main: {
@@ -308,7 +306,6 @@ context('A user can add an appointment', () => {
     const prePostForm = prePostAppointmentsPage.form()
 
     prePostForm.preAppointmentLocation().select('1')
-    prePostForm.preAppointmentDuration().select('20')
     prePostForm.postAppointmentNo().click()
     prePostForm.court().select('Other')
     prePostForm.submitButton().click()
@@ -346,7 +343,6 @@ context('A user can add an appointment', () => {
     const prePostForm = prePostAppointmentsPage.form()
 
     prePostForm.preAppointmentLocation().select('1')
-    prePostForm.preAppointmentDuration().select('20')
     prePostForm.postAppointmentNo().click()
     prePostForm.court().select('Other')
     prePostForm.submitButton().click()
@@ -365,10 +361,6 @@ context('A user can add an appointment', () => {
       .form()
       .preAppointmentLocation()
       .contains('1')
-    returnPrePostAppointmentsPage
-      .form()
-      .preAppointmentDuration()
-      .contains('20')
     returnPrePostAppointmentsPage
       .form()
       .postAppointmentNo()

--- a/integration-tests/pages/appointments/prePostAppointmentsPage.js
+++ b/integration-tests/pages/appointments/prePostAppointmentsPage.js
@@ -5,11 +5,9 @@ const prePostAppointmentsPage = () =>
     form: () => ({
       preAppointmentYes: () => cy.get('#preAppointment'),
       preAppointmentLocation: () => cy.get('#preAppointmentLocation'),
-      preAppointmentDuration: () => cy.get('#preAppointmentDuration'),
       preAppointmentNo: () => cy.get('#preAppointment-2'),
       postAppointmentYes: () => cy.get('#postAppointment'),
       postAppointmentLocation: () => cy.get('#postAppointmentLocation'),
-      postAppointmentDuration: () => cy.get('#postAppointmentDuration'),
       postAppointmentNo: () => cy.get('#postAppointment-2'),
       court: () => cy.get('#court'),
       submitButton: () => cy.get('button[type="submit"]'),

--- a/views/enterCustomCourt.njk
+++ b/views/enterCustomCourt.njk
@@ -23,9 +23,6 @@
                 <input type="hidden" name="preAppointment" value="{{  formValues.preAppointment }}"/>
                 <input type="hidden" name="postAppointment" value="{{ formValues.postAppointment }}"/>
 
-                <input type="hidden" name="preAppointmentDuration" value="{{ formValues.preAppointmentDuration }}"/>
-                <input type="hidden" name="postAppointmentDuration" value="{{ formValues.postAppointmentDuration }}"/>
-
                 <input type="hidden" name="preAppointmentLocation" value="{{ formValues.preAppointmentLocation }}"/>
                 <input type="hidden" name="postAppointmentLocation" value="{{ formValues.postAppointmentLocation }}"/>
                 <input type="hidden" name="otherCourtForm" value="true"/>

--- a/views/prepostAppointments.njk
+++ b/views/prepostAppointments.njk
@@ -22,22 +22,6 @@
                 items: locations | addDefaultSelectedVale('Select') | setSelected(params.location),
                 errorMessage: errors | findError(params.name + "Location")
             }) }}
-
-            {{ govukSelect({
-                name: params.name + "Duration",
-                id: params.name + "Duration",
-                label: {
-                    text: "Duration"
-                },
-                items: [
-                    { text: '20 minutes', value: '20' },
-                    { text: '30 minutes', value: '30' },
-                    { text: '40 minutes', value: '40' },
-                    { text: '50 minutes', value: '50' },
-                    { text: '1 hour', value: '60' }
-                ] | setSelected(params.duration),
-                errorMessage: errors | findError(params.name + "Duration")
-            }) }}
         </div>
 
         <div id="{{ 'location-events-' + params.name }}" class="govuk-grid-column-one-half">

--- a/views/prepostAppointments.njk
+++ b/views/prepostAppointments.njk
@@ -33,11 +33,11 @@
 {% endmacro %}
 
 {% set preAppointmentHtml %}
-    {{ appointment({name:"preAppointment",locations: locations, location: formValues.preAppointmentLocation, duration: formValues.preAppointmentDuration}) }}
+    {{ appointment({name:"preAppointment",locations: locations, location: formValues.preAppointmentLocation }) }}
 {% endset -%}
 
 {% set postAppointmentHtml %}
-    {{ appointment({name:"postAppointment",locations: locations, location: formValues.postAppointmentLocation, duration: formValues.postAppointmentDuration}) }}
+    {{ appointment({name:"postAppointment",locations: locations, location: formValues.postAppointmentLocation }) }}
 {% endset -%}
 
 {% block content %}


### PR DESCRIPTION
Removing the ability to specify pre/post appointment duration - these will now always be 15 mins long instead.
