### PR TITLE
NN-3383 fix error message format

### DIFF
--- a/backend/controllers/cellMove/cellMovePrisonerSearch.js
+++ b/backend/controllers/cellMove/cellMovePrisonerSearch.js
@@ -11,7 +11,7 @@ module.exports = ({ prisonApi }) => async (req, res) => {
     const hasSearched = keywords !== undefined
     const emptySearchError = {
       href: '#keywords',
-      html: 'Enter a prisoner&#8217;s name or number',
+      text: 'Enter a prisoner’s name or number',
     }
     return res.render('cellMove/cellMovePrisonerSearch.njk', {
       showResults: false,

--- a/backend/controllers/cellMove/cellMoveTemporaryMove.js
+++ b/backend/controllers/cellMove/cellMoveTemporaryMove.js
@@ -10,7 +10,7 @@ module.exports = ({ prisonApi }) => async (req, res) => {
     const hasSearched = keywords !== undefined
     const emptySearchError = {
       href: '#keywords',
-      html: 'Enter a prisoner&#8217;s name or number',
+      text: 'Enter a prisoner’s name or number',
     }
     return res.render('cellMove/cellMoveTemporaryMove.njk', {
       showResults: false,

--- a/backend/controllers/cellMove/cellMoveViewResidentialLocation.js
+++ b/backend/controllers/cellMove/cellMoveViewResidentialLocation.js
@@ -36,7 +36,7 @@ module.exports = ({ prisonApi, whereaboutsApi }) => async (req, res) => {
   if (noLocationSelected) {
     const noLocationSelectedError = {
       href: '#location',
-      html: 'Select a residential location',
+      text: 'Select a residential location',
     }
     return res.render('cellMove/cellMoveViewResidentialLocation.njk', {
       showResults: false,

--- a/backend/tests/cellMove/cellMovePrisonerSearch.test.js
+++ b/backend/tests/cellMove/cellMovePrisonerSearch.test.js
@@ -179,7 +179,7 @@ describe('Prisoner search', () => {
           errors: [
             {
               href: '#keywords',
-              html: 'Enter a prisoner&#8217;s name or number',
+              text: 'Enter a prisoner’s name or number',
             },
           ],
         })

--- a/backend/tests/cellMove/cellMoveTemporaryMove.test.js
+++ b/backend/tests/cellMove/cellMoveTemporaryMove.test.js
@@ -172,7 +172,7 @@ describe('Move someone temporarily out of a cell', () => {
           errors: [
             {
               href: '#keywords',
-              html: 'Enter a prisoner&#8217;s name or number',
+              text: 'Enter a prisoner’s name or number',
             },
           ],
         })

--- a/backend/tests/cellMove/cellMoveViewResidentialLocation.test.js
+++ b/backend/tests/cellMove/cellMoveViewResidentialLocation.test.js
@@ -294,7 +294,7 @@ describe('View Residential Location', () => {
           errors: [
             {
               href: '#location',
-              html: 'Select a residential location',
+              text: 'Select a residential location',
             },
           ],
         })

--- a/views/cellMove/cellMovePrisonerSearch.njk
+++ b/views/cellMove/cellMovePrisonerSearch.njk
@@ -52,7 +52,9 @@
         classes: 'govuk-!-width-full',
         attributes: {
           'data-test': 'prisoner-search-keywords'
-        }
+        },
+        errorMessage: errors | findError('keywords')
+
       }) }}
 
       {{ govukButton({

--- a/views/cellMove/cellMoveTemporaryMove.njk
+++ b/views/cellMove/cellMoveTemporaryMove.njk
@@ -51,7 +51,9 @@
         classes: 'govuk-!-width-full',
         attributes: {
           'data-test': 'prisoner-search-keywords'
-        }
+        },
+        errorMessage: errors | findError('keywords')
+
       }) }}
 
       {{ govukButton({

--- a/views/cellMove/cellMoveViewResidentialLocation.njk
+++ b/views/cellMove/cellMoveViewResidentialLocation.njk
@@ -51,7 +51,9 @@
         items: locationOptions | setSelected(formValues.location),
         attributes: {
           'data-test': 'prisoner-search-location'
-        }
+        },
+        errorMessage: errors | findError('location')
+
       }) }}
 
       {{ govukButton({


### PR DESCRIPTION
I think the missing error messages at the location of the error was caused by a missing piece of code in the njk file, though the actual error message at that point wasn't recognised whilst it was using the 'html' key in the controller (used so that we could specify the correct apostrophe code), so I've swapped that out for the plain text version. I've checked the apostrophe and it matches the one we had previously.

<img width="1440" alt="Screenshot 2021-06-18 at 09 21 35" src="https://user-images.githubusercontent.com/84783598/122536331-5180f680-d01c-11eb-8905-61a8c02b2703.png">
<img width="1440" alt="Screenshot 2021-06-18 at 09 21 42" src="https://user-images.githubusercontent.com/84783598/122536336-52b22380-d01c-11eb-9345-2e3b8de7f552.png">
<img width="1440" alt="Screenshot 2021-06-18 at 09 22 26" src="https://user-images.githubusercontent.com/84783598/122536339-534aba00-d01c-11eb-975e-ae2238dfff1b.png">
