### PR TITLE
NN-3279 use offender search to determine if the prisoner has a life sentence term

### DIFF
--- a/backend/api/offenderSearchApi.js
+++ b/backend/api/offenderSearchApi.js
@@ -33,8 +33,16 @@ const offenderSearchApiFactory = client => {
     )
   }
 
+  const getPrisonersDetails = async (context, prisonerNumbers) => {
+    // const res = await client.post(context, '/prisoner-search/prisoner-numbers', { prisonerNumbers })
+    // return res.body
+      console.log('Hello')
+      return [{}]
+  }
+
   return {
     globalSearch,
+    getPrisonersDetails,
   }
 }
 

--- a/backend/api/offenderSearchApi.js
+++ b/backend/api/offenderSearchApi.js
@@ -34,12 +34,8 @@ const offenderSearchApiFactory = client => {
   }
 
   const getPrisonersDetails = async (context, prisonerNumbers) => {
-      console.log('in ')
     const res = await client.post(context, '/prisoner-search/prisoner-numbers', { prisonerNumbers })
-      console.log('out ')
     return res.body
-    //   console.log('Hello')
-    //   return [{}]
   }
 
   return {

--- a/backend/api/offenderSearchApi.js
+++ b/backend/api/offenderSearchApi.js
@@ -34,10 +34,12 @@ const offenderSearchApiFactory = client => {
   }
 
   const getPrisonersDetails = async (context, prisonerNumbers) => {
-    // const res = await client.post(context, '/prisoner-search/prisoner-numbers', { prisonerNumbers })
-    // return res.body
-      console.log('Hello')
-      return [{}]
+      console.log('in ')
+    const res = await client.post(context, '/prisoner-search/prisoner-numbers', { prisonerNumbers })
+      console.log('out ')
+    return res.body
+    //   console.log('Hello')
+    //   return [{}]
   }
 
   return {

--- a/backend/controllers/prisonerProfile/prisonerQuickLook.js
+++ b/backend/controllers/prisonerProfile/prisonerQuickLook.js
@@ -16,13 +16,12 @@ const trackEvent = (telemetry, username, activeCaseLoad) => {
 }
 
 const captureErrorAndContinue = apiCall =>
-    [{}]
-  // new Promise(resolve => {
-  //   apiCall.then(response => resolve({ response })).catch(error => {
-  //     log.error(error)
-  //     resolve({ error: true })
-  //   })
-  // })
+  new Promise(resolve => {
+    apiCall.then(response => resolve({ response })).catch(error => {
+      log.error(error)
+      resolve({ error: true })
+    })
+  })
 
 const extractResponse = (complexData, key) => {
   if (!complexData || complexData.error) return null
@@ -82,7 +81,6 @@ module.exports = ({ prisonerProfileService, prisonApi, telemetry, offenderSearch
     nextVisitResponse,
     visitBalancesResponse,
     todaysEventsResponse,
-    prisonerDetailsResponse,
   ] = await Promise.all(
     [
       prisonerProfileService.getPrisonerProfileData(res.locals, offenderNo, username),
@@ -96,26 +94,15 @@ module.exports = ({ prisonerProfileService, prisonApi, telemetry, offenderSearch
       prisonApi.getAdjudicationsForBooking(res.locals, bookingId),
       prisonApi.getNextVisit(res.locals, bookingId),
       prisonApi.getPrisonerVisitBalances(res.locals, offenderNo),
-      prisonApi.getEventsForToday(res.locals, bookingId),
-      //
-      // [{}],
-      // [{}],
-      // [{}],
-      // [{}],
-      // [{}],
-      // [{}],
-      // [{}],
-      // [{}],
-      // [{}],
-      // [{}],
-      // [{}],
-      // [{}],
-      [{}],
-      // offenderSearchApi.getPrisonersDetails(res.locals, [offenderNo]),
+      prisonApi.getEventsForToday(res.locals, bookingId)
     ].map(apiCall => captureErrorAndContinue(apiCall))
   )
 
   console.log('2')
+  const prisonerDetailsResponse = await offenderSearchApi.getPrisonersDetails(res.locals, [offenderNo])
+
+  console.log('3')
+
   const [
     prisonerProfileData,
     offenceData,

--- a/backend/controllers/prisonerProfile/prisonerQuickLook.js
+++ b/backend/controllers/prisonerProfile/prisonerQuickLook.js
@@ -125,10 +125,8 @@ module.exports = ({ prisonerProfileService, prisonApi, telemetry, offenderSearch
 
   trackEvent(telemetry, username, activeCaseLoad)
 
-  const extractLifeImprisonmentStatus = async () => {
-    const [prisonerDetailsResponse] = await Promise.all(
-      [offenderSearchApi.getPrisonersDetails(res.locals, [offenderNo])].map(apiCall => captureErrorAndContinue(apiCall))
-    )
+  const getLifeImprisonmentLabel = async () => {
+    const prisonerDetailsResponse = await captureErrorAndContinue(offenderSearchApi.getPrisonersDetails(res.locals, [offenderNo]))
 
     if (prisonerDetailsResponse.error) {
       return unableToShowDetailMessage
@@ -163,7 +161,7 @@ module.exports = ({ prisonerProfileService, prisonApi, telemetry, offenderSearch
               sentenceData.sentenceDetail &&
               sentenceData.sentenceDetail.releaseDate &&
               moment(sentenceData.sentenceDetail.releaseDate).format('D MMMM YYYY')) ||
-            (await extractLifeImprisonmentStatus()),
+            (await getLifeImprisonmentLabel()),
       },
     ],
     balanceDetailsSectionError: Boolean(balanceDataResponse.error),

--- a/backend/controllers/prisonerProfile/prisonerQuickLook.js
+++ b/backend/controllers/prisonerProfile/prisonerQuickLook.js
@@ -126,7 +126,9 @@ module.exports = ({ prisonerProfileService, prisonApi, telemetry, offenderSearch
   trackEvent(telemetry, username, activeCaseLoad)
 
   const getLifeImprisonmentLabel = async () => {
-    const prisonerDetailsResponse = await captureErrorAndContinue(offenderSearchApi.getPrisonersDetails(res.locals, [offenderNo]))
+    const prisonerDetailsResponse = await captureErrorAndContinue(
+      offenderSearchApi.getPrisonersDetails(res.locals, [offenderNo])
+    )
 
     if (prisonerDetailsResponse.error) {
       return unableToShowDetailMessage

--- a/backend/controllers/prisonerProfile/prisonerSentenceAndRelease.js
+++ b/backend/controllers/prisonerProfile/prisonerSentenceAndRelease.js
@@ -3,7 +3,7 @@ const sentenceAdjustmentsViewModel = require('./sentenceAndReleaseViewModels/sen
 const courtCasesViewModel = require('./sentenceAndReleaseViewModels/courtCasesViewModel')
 const { readableDateFormat } = require('../../utils')
 
-module.exports = ({ prisonerProfileService, prisonApi, systemOauthClient }) => async (req, res) => {
+module.exports = ({ prisonerProfileService, prisonApi, systemOauthClient, offenderSearchApi }) => async (req, res) => {
   const { offenderNo } = req.params
 
   const { username } = req.session.userDetails
@@ -29,8 +29,8 @@ module.exports = ({ prisonerProfileService, prisonApi, systemOauthClient }) => a
   const courtCases = courtCasesViewModel({ courtCaseData, sentenceTermsData, offenceHistory })
 
   const determineLifeSentence = async () => {
-    const prisonerDetails = await prisonApi.getPrisonerDetails(res.locals, offenderNo)
-    return prisonerDetails && prisonerDetails[0]?.imprisonmentStatus === 'LIFE' ? 'Life sentence' : undefined
+    const prisonerDetails = await offenderSearchApi.getPrisonersDetails(res.locals, [offenderNo])
+    return prisonerDetails && prisonerDetails[0]?.indeterminateSentence ? 'Life sentence' : undefined
   }
 
   const getEffectiveSentenceEndDate = async () =>

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -214,6 +214,7 @@ const setup = ({
       socApi,
       whereaboutsApi,
       complexityApi,
+      offenderSearchApi,
     })
   )
 

--- a/backend/routes/prisonerProfileRouter.js
+++ b/backend/routes/prisonerProfileRouter.js
@@ -91,7 +91,7 @@ const controller = ({
   )
   router.get(
     '/sentence-and-release',
-    prisonerSentenceAndRelease({ prisonerProfileService, prisonApi, systemOauthClient, logError })
+    prisonerSentenceAndRelease({ prisonerProfileService, prisonApi, systemOauthClient, offenderSearchApi, logError })
   )
   router.get('/visits', prisonerVisits({ prisonApi, logError }))
   router.get('/schedule', prisonerSchedule({ prisonApi, logError }))

--- a/backend/routes/prisonerProfileRouter.js
+++ b/backend/routes/prisonerProfileRouter.js
@@ -49,6 +49,7 @@ const controller = ({
   socApi,
   whereaboutsApi,
   complexityApi,
+  offenderSearchApi,
 }) => {
   const prisonerProfileService = prisonerProfileServiceFactory({
     prisonApi,
@@ -60,13 +61,14 @@ const controller = ({
     socApi,
     allocationManagerApi,
     complexityApi,
+    offenderSearchApi,
   })
   const personService = personServiceFactory(prisonApi)
   const prisonerFinanceService = prisonerFinanceServiceFactory(prisonApi)
   const referenceCodesService = referenceCodesServiceFactory(prisonApi)
   const adjudicationHistoryService = adjudicationsHistoryService(prisonApi)
 
-  router.get('/', prisonerQuickLook({ prisonerProfileService, prisonApi, telemetry, logError }))
+  router.get('/', prisonerQuickLook({ prisonerProfileService, prisonApi, telemetry, offenderSearchApi, logError }))
   router.get('/image', prisonerFullImage({ prisonApi, logError }))
   router.get(
     '/personal',

--- a/backend/routes/prisonerProfileRouter.js
+++ b/backend/routes/prisonerProfileRouter.js
@@ -61,7 +61,6 @@ const controller = ({
     socApi,
     allocationManagerApi,
     complexityApi,
-    offenderSearchApi,
   })
   const personService = personServiceFactory(prisonApi)
   const prisonerFinanceService = prisonerFinanceServiceFactory(prisonApi)

--- a/backend/tests/prisonerQuickLook.test.js
+++ b/backend/tests/prisonerQuickLook.test.js
@@ -65,6 +65,8 @@ describe('prisoner profile quick look', () => {
 
     telemetry.trackEvent = jest.fn().mockResolvedValue([])
 
+    offenderSearchApi.getPrisonersDetails = jest.fn().mockResolvedValue([])
+
     controller = prisonerQuickLook({ prisonerProfileService, prisonApi, telemetry, offenderSearchApi, logError })
   })
 
@@ -167,6 +169,7 @@ describe('prisoner profile quick look', () => {
           { imprisonmentStatus: 'LIFE', imprisonmentStatusDesc: 'Serving Life Imprisonment' },
         ])
         prisonApi.getPrisonerSentenceDetails.mockResolvedValue({ sentenceDetail: { releaseDate: '' } })
+        offenderSearchApi.getPrisonersDetails.mockResolvedValue([{ indeterminateSentence: true }])
 
         await controller(req, res)
 
@@ -750,10 +753,12 @@ describe('prisoner profile quick look', () => {
       )
     })
     it('should handle api errors when requesting imprisonment status and release date is not set', async () => {
+      const error = new Error('Network error')
       prisonApi.getPrisonerSentenceDetails.mockResolvedValue({ sentenceDetail: { releaseDate: '' } })
       prisonApi.getMainOffence.mockResolvedValue([
         { offenceDescription: 'Have blade/article which was sharply pointed in public place' },
       ])
+      offenderSearchApi.getPrisonersDetails.mockRejectedValue(error)
 
       await controller(req, res)
 

--- a/backend/tests/prisonerQuickLook.test.js
+++ b/backend/tests/prisonerQuickLook.test.js
@@ -19,6 +19,7 @@ describe('prisoner profile quick look', () => {
   }
   const bookingId = '123'
   const prisonApi = {}
+  const offenderSearchApi = {}
   const prisonerProfileService = {}
   const telemetry = {}
 
@@ -64,7 +65,7 @@ describe('prisoner profile quick look', () => {
 
     telemetry.trackEvent = jest.fn().mockResolvedValue([])
 
-    controller = prisonerQuickLook({ prisonerProfileService, prisonApi, telemetry, logError })
+    controller = prisonerQuickLook({ prisonerProfileService, prisonApi, telemetry, offenderSearchApi, logError })
   })
 
   it('should make a call for the basic details of a prisoner and the prisoner header details and render them', async () => {

--- a/backend/tests/prisonerQuickLook.test.js
+++ b/backend/tests/prisonerQuickLook.test.js
@@ -164,7 +164,7 @@ describe('prisoner profile quick look', () => {
         )
       })
 
-      it('should show Life Imprisonment alongside the release date if no release date is set and the offender is serving LIFE', async () => {
+      it('should show Life Imprisonment alongside the release date if no release date is set and the offender has a life term', async () => {
         prisonApi.getPrisonerDetails.mockResolvedValue([
           { imprisonmentStatus: 'LIFE', imprisonmentStatusDesc: 'Serving Life Imprisonment' },
         ])
@@ -188,6 +188,36 @@ describe('prisoner profile quick look', () => {
               {
                 label: 'Release date',
                 value: 'Life sentence',
+              },
+            ],
+          })
+        )
+      })
+
+      it('should show Not entered alongside the release date if no release date is set and the offender is not on a life term', async () => {
+        prisonApi.getPrisonerDetails.mockResolvedValue([
+          { imprisonmentStatus: 'LIFE', imprisonmentStatusDesc: 'Serving Life Imprisonment' },
+        ])
+        prisonApi.getPrisonerSentenceDetails.mockResolvedValue({ sentenceDetail: { releaseDate: '' } })
+        offenderSearchApi.getPrisonersDetails.mockResolvedValue([{ indeterminateSentence: false }])
+
+        await controller(req, res)
+
+        expect(res.render).toHaveBeenCalledWith(
+          'prisonerProfile/prisonerQuickLook/prisonerQuickLook.njk',
+          expect.objectContaining({
+            offenceDetails: [
+              {
+                label: 'Main offence',
+                value: 'Have blade/article which was sharply pointed in public place',
+              },
+              {
+                label: 'Imprisonment status',
+                value: 'Serving Life Imprisonment',
+              },
+              {
+                label: 'Release date',
+                value: 'Not entered',
               },
             ],
           })

--- a/backend/tests/prisonerSentenceAndRelease.test.js
+++ b/backend/tests/prisonerSentenceAndRelease.test.js
@@ -19,6 +19,7 @@ describe('prisoner sentence and release', () => {
   const prisonerProfileService = {}
   const prisonApi = {}
   const systemOauthClient = {}
+  const offenderSearchApi = {}
 
   let req
   let res
@@ -84,6 +85,7 @@ describe('prisoner sentence and release', () => {
       prisonerProfileService,
       prisonApi,
       systemOauthClient,
+      offenderSearchApi,
       logError,
     })
   })
@@ -1034,7 +1036,7 @@ describe('prisoner sentence and release', () => {
         releaseDate: '2020-04-01',
       },
     })
-    prisonApi.getPrisonerDetails = jest.fn().mockResolvedValue([{ latestBookingId: 1, imprisonmentStatus: 'LIFE' }])
+    offenderSearchApi.getPrisonersDetails = jest.fn().mockResolvedValue([{ indeterminateSentence: true }])
 
     await controller(req, res)
 
@@ -1054,7 +1056,7 @@ describe('prisoner sentence and release', () => {
         releaseDate: '2020-04-01',
       },
     })
-    prisonApi.getPrisonerDetails = jest.fn().mockResolvedValue([{ latestBookingId: 1, imprisonmentStatus: 'OTHER' }])
+    offenderSearchApi.getPrisonersDetails = jest.fn().mockResolvedValue([{ indeterminateSentence: false }])
 
     await controller(req, res)
 

--- a/integration-tests/integration/prisonerProfile/prisonerSentenceAndRelease.spec.js
+++ b/integration-tests/integration/prisonerProfile/prisonerSentenceAndRelease.spec.js
@@ -35,7 +35,7 @@ context('Prisoner sentence and release', () => {
       offenderNo: 'A12345',
     })
     cy.task('stubOffenderBasicDetails', { bookingId: 1 })
-    cy.task('stubPrisonerDetails', prisonerDetails)
+    cy.task('stubPrisonerSearch')
     cy.task('stubClientCredentialsRequest')
   })
 

--- a/integration-tests/mockApis/offenderSearch.js
+++ b/integration-tests/mockApis/offenderSearch.js
@@ -47,6 +47,24 @@ module.exports = {
         ],
       },
     }),
+  stubPrisonerSearch: () =>
+    postFor({
+      urlPattern: '/offenderSearch/prisoner-search/prisoner-numbers',
+      body: {
+        totalElements: 2,
+        pageable: { pageSize: 20, offset: 0 },
+        content:  [
+          {
+            prisonerNumber: 'A1234AC',
+            indeterminiteSentence: false,
+          },
+          {
+            prisonerNumber: 'A1234AA',
+            indeterminiteSentence: false,
+          },
+        ],
+      },
+    }),
   verifyGlobalSearch: () =>
     getMatchingRequests({
       method: 'POST',

--- a/integration-tests/plugins/index.js
+++ b/integration-tests/plugins/index.js
@@ -448,5 +448,6 @@ module.exports = on => {
     stubGetAppointment: ({ appointment, id, status }) => whereabouts.stubGetAppointment({ appointment, id, status }),
     stubDeleteAppointment: ({ id, status }) => whereabouts.stubDeleteAppointment({ id, status }),
     stubDeleteRecurringAppointmentSequence: ({ id, status }) => whereabouts.stubDeleteRecurringAppointmentSequence({ id, status }),
+    stubPrisonerSearch: () => offenderSearch.stubPrisonerSearch(),
   })
 }


### PR DESCRIPTION
The original implementation was relying on a prison-api call to determine if the offender had a Life term, however that didnt quite work in all scenarios. It needed some extra derivation on the sentence terms - after a slack chat with other dps devs it turns out the prisoner search service does this derivation https://mojdt.slack.com/archives/C012FNNQ4A3/p1623854264294400

So changed it to call the elastic  prisoner-search-service which returns a flag which fits our purpose.