### PR TITLE
NN-3481: implement functional skills levels

### DIFF
--- a/backend/api/curious/curiousApi.test.ts
+++ b/backend/api/curious/curiousApi.test.ts
@@ -9,7 +9,7 @@ describe('curiousApi', () => {
       expect(actual).toEqual(dummyLearnerProfiles)
     })
   })
-  describe('getFunctionalSkillsLevels', () => {
+  describe('getLearnerLatestAssessments', () => {
     it('should return the expected response data', async () => {
       const actual = await curiousApi.getLearnerLatestAssessments('abc')
       expect(actual).toEqual(dummyLearnerLatestAssessments)

--- a/backend/api/curious/curiousApi.test.ts
+++ b/backend/api/curious/curiousApi.test.ts
@@ -1,4 +1,4 @@
-import CuriousApi, { dummyLearnerProfiles } from './curiousApi'
+import CuriousApi, { dummyLearnerProfiles, dummyLearnerLatestAssessments } from './curiousApi'
 
 const curiousApi = CuriousApi.create()
 
@@ -7,6 +7,12 @@ describe('curiousApi', () => {
     it('should return the expected response data', async () => {
       const actual = await curiousApi.getLearnerProfiles('abc')
       expect(actual).toEqual(dummyLearnerProfiles)
+    })
+  })
+  describe('getFunctionalSkillsLevels', () => {
+    it('should return the expected response data', async () => {
+      const actual = await curiousApi.getLearnerLatestAssessments('abc')
+      expect(actual).toEqual(dummyLearnerLatestAssessments)
     })
   })
 })

--- a/backend/api/curious/curiousApi.ts
+++ b/backend/api/curious/curiousApi.ts
@@ -38,6 +38,59 @@ export const dummyLearnerProfiles: curious.LearnerProfile[] = [
   },
 ]
 
+export const dummyLearnerLatestAssessments: curious.LearnerLatestAssessment[] = [
+  {
+    prn: 'G8346GA',
+    qualifications: [
+      {
+        establishmentId: 2,
+        establishmentName: 'HMP Winchester',
+        qualification: {
+          qualificationType: 'English',
+          qualificationGrade: 'Entry Level 2',
+          assessmentDate: '2021-05-02',
+        },
+      },
+      {
+        establishmentId: 2,
+        establishmentName: 'HMP Winchester',
+        qualification: {
+          qualificationType: 'English',
+          qualificationGrade: 'Entry Level 2',
+          assessmentDate: '2020-12-02',
+        },
+      },
+      {
+        establishmentId: 2,
+        establishmentName: 'HMP Winchester',
+        qualification: {
+          qualificationType: 'Digital Literacy',
+          qualificationGrade: 'Entry Level 1',
+          assessmentDate: '2020-06-01',
+        },
+      },
+      {
+        establishmentId: 2,
+        establishmentName: 'HMP Winchester',
+        qualification: {
+          qualificationType: 'Digital Literacy',
+          qualificationGrade: 'Entry Level 2',
+          assessmentDate: '2021-06-01',
+        },
+      },
+      {
+        establishmentId: 2,
+        establishmentName: 'HMP Winchester',
+        qualification: {
+          qualificationType: 'Maths',
+          qualificationGrade: 'Entry Level 2',
+          assessmentDate: '2021-06-06',
+        },
+      },
+    ],
+  },
+]
+
 export default class CuriousApi {
   static create(): CuriousApi {
     return new CuriousApi()
@@ -46,5 +99,9 @@ export default class CuriousApi {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getLearnerProfiles(nomisId: string): Promise<curious.LearnerProfile[]> {
     return Promise.resolve(dummyLearnerProfiles)
+  }
+
+  getLearnerLatestAssessments(nomisId: string): Promise<curious.LearnerLatestAssessment[]> {
+    return Promise.resolve(dummyLearnerLatestAssessments)
   }
 }

--- a/backend/api/curious/types/AssessmentQualificationType.ts
+++ b/backend/api/curious/types/AssessmentQualificationType.ts
@@ -1,0 +1,7 @@
+enum AssessmentQualificationType {
+  English = 'English',
+  Maths = 'Maths',
+  DigitalLiteracy = 'Digital Literacy',
+}
+
+export default AssessmentQualificationType

--- a/backend/api/curious/types/LearnerEducationDeliveryMethodType.ts
+++ b/backend/api/curious/types/LearnerEducationDeliveryMethodType.ts
@@ -1,0 +1,7 @@
+enum LearnerEducationDeliveryMethodType {
+  BlendedLearning = 'Blended Learning',
+  ClassroomOnlyLearning = 'Classroom Only Learning',
+  PackOnlyLearning = 'Pack Only Learning',
+}
+
+export default LearnerEducationDeliveryMethodType

--- a/backend/api/curious/types/index.d.ts
+++ b/backend/api/curious/types/index.d.ts
@@ -418,4 +418,30 @@ declare namespace curious {
      */
     qualifications?: LearnerAssessment[]
   }
+
+  /**
+   *
+   * @export
+   * @interface FunctionalSkillsLevels
+   */
+  export interface FunctionalSkillsLevels {
+    /**
+     *
+     * @type {Array<FunctionalSkillsLevels>}
+     * @memberof FunctionalSkillsLevels
+     */
+    english?: Array
+    /**
+     *
+     * @type {Array<FunctionalSkillsLevels>}
+     * @memberof FunctionalSkillsLevels
+     */
+    maths?: Array
+    /**
+     *
+     * @type {Array<FunctionalSkillsLevels>}
+     * @memberof FunctionalSkillsLevels
+     */
+    digiLit?: Array
+  }
 }

--- a/backend/api/curious/types/index.d.ts
+++ b/backend/api/curious/types/index.d.ts
@@ -1,4 +1,7 @@
 declare namespace curious {
+  type AssessmentQualificationType = import('AssessmentQualificationType')
+  type LearnerEducationDeliveryMethodType = import('LearnerEducationDeliveryMethodType')
+
   /**
    *
    * @export
@@ -23,16 +26,6 @@ declare namespace curious {
      * @memberof Assessment
      */
     qualificationType?: AssessmentQualificationType
-  }
-
-  /**
-   * @export
-   * @enum {string}
-   */
-  export enum AssessmentQualificationType {
-    English = 'English',
-    Maths = 'Maths',
-    DigitalLiteracy = 'Digital Literacy',
   }
 
   /**
@@ -387,16 +380,6 @@ declare namespace curious {
      * @memberof LearnerProfile
      */
     uln?: string
-  }
-
-  /**
-   * @export
-   * @enum {string}
-   */
-  export enum LearnerEducationDeliveryMethodType {
-    BlendedLearning = 'Blended Learning',
-    ClassroomOnlyLearning = 'Classroom Only Learning',
-    PackOnlyLearning = 'Pack Only Learning',
   }
 
   /**

--- a/backend/controllers/prisonerProfile/prisonerWorkAndSkills.js
+++ b/backend/controllers/prisonerProfile/prisonerWorkAndSkills.js
@@ -1,0 +1,19 @@
+const logErrorAndContinue = require('../../shared/logErrorAndContinue')
+
+module.exports =
+  ({ prisonerProfileService, esweService }) =>
+  async (req, res) => {
+    const { offenderNo } = req.params
+
+    const [prisonerProfileData, functionalSkillLevels] = await Promise.all(
+      [
+        prisonerProfileService.getPrisonerProfileData(res.locals, offenderNo),
+        esweService.getFunctionalSkillsLevels(offenderNo),
+      ].map((apiCall) => logErrorAndContinue(apiCall))
+    )
+
+    return res.render('prisonerProfile/prisonerWorkAndSkills/prisonerWorkAndSkills.njk', {
+      prisonerProfileData,
+      functionalSkillLevels,
+    })
+  }

--- a/backend/controllers/prisonerProfile/prisonerWorkAndSkills.js
+++ b/backend/controllers/prisonerProfile/prisonerWorkAndSkills.js
@@ -8,7 +8,7 @@ module.exports =
     const [prisonerProfileData, functionalSkillLevels] = await Promise.all(
       [
         prisonerProfileService.getPrisonerProfileData(res.locals, offenderNo),
-        esweService.getFunctionalSkillsLevels(offenderNo),
+        esweService.getLearnerLatestAssessments(offenderNo),
       ].map((apiCall) => logErrorAndContinue(apiCall))
     )
 

--- a/backend/routes/prisonerProfileRouter.js
+++ b/backend/routes/prisonerProfileRouter.js
@@ -21,6 +21,7 @@ const prisonerIncentiveLevelDetails = require('../controllers/prisonerProfile/pr
 const prisonerChangeIncentiveLevelDetails = require('../controllers/prisonerProfile/prisonerChangeIncentiveLevelDetails')
 const prisonerCsraHistory = require('../controllers/prisonerProfile/prisonerCsraHistory')
 const prisonerCsraReview = require('../controllers/prisonerProfile/prisonerCsraReview')
+const prisonerWorkAndSkills = require('../controllers/prisonerProfile/prisonerWorkAndSkills')
 
 const prisonerDamageObligations = require('../controllers/prisonerProfile/prisonerFinances/prisonerDamageObligations')
 const prisonerPrivateCash = require('../controllers/prisonerProfile/prisonerFinances/prisonerPrivateCash')
@@ -97,6 +98,7 @@ const controller = ({
     '/sentence-and-release',
     prisonerSentenceAndRelease({ prisonerProfileService, prisonApi, systemOauthClient, offenderSearchApi, logError })
   )
+  router.get('/work-and-skills', prisonerWorkAndSkills({ prisonerProfileService, esweService }))
   router.get('/visits', prisonerVisits({ prisonApi, logError }))
   router.get('/schedule', prisonerSchedule({ prisonApi, logError }))
   router.get(

--- a/backend/services/esweService.ts
+++ b/backend/services/esweService.ts
@@ -1,4 +1,5 @@
 import { app } from '../config'
+import { readableDateFormat } from '../utils'
 import type CuriousApi from '../api/curious/curiousApi'
 
 type FeatureFlagged<T> = {
@@ -7,6 +8,7 @@ type FeatureFlagged<T> = {
 }
 
 type LearnerProfiles = FeatureFlagged<curious.LearnerProfile[]>
+type LearnerLatestAssessments = FeatureFlagged<curious.FunctionalSkillsLevels>
 
 /**
  * Education skills and work experience (ESWE)
@@ -29,6 +31,64 @@ export default class EsweService {
     return {
       enabled: app.esweEnabled,
       content: await this.curiousApi.getLearnerProfiles(nomisId),
+    }
+  }
+
+  async getLearnerLatestAssessments(nomisId: string): Promise<LearnerLatestAssessments> {
+    if (!app.esweEnabled) {
+      return {
+        enabled: app.esweEnabled,
+        content: {},
+      }
+    }
+
+    const content = await this.curiousApi.getLearnerLatestAssessments(nomisId)
+
+    const filterSkillsAndGetLatestGrade = (functionalSkillLevels, skillToFilter) =>
+      functionalSkillLevels[0].qualifications
+        .filter((functionalSkillLevel) => functionalSkillLevel.qualification.qualificationType === skillToFilter)
+        .sort(
+          (a, b) =>
+            new Date(b.qualification.assessmentDate).getTime() - new Date(a.qualification.assessmentDate).getTime()
+        )[0]
+
+    const englishSkillLevels = filterSkillsAndGetLatestGrade(content, 'English') || { skill: 'English/Welsh' }
+    const mathsSkillLevels = filterSkillsAndGetLatestGrade(content, 'Maths') || { skill: 'Maths' }
+    const digiLitSkillLevels = filterSkillsAndGetLatestGrade(content, 'Digital Literacy') || {
+      skill: 'Digital Literacy',
+    }
+
+    const createSkillAssessmentSummary = (skillAssessment) => {
+      if (!skillAssessment.qualification) return [{ label: skillAssessment.skill, value: 'Awaiting assessment' }]
+
+      const { qualificationType, qualificationGrade, assessmentDate } = skillAssessment.qualification
+      const { establishmentName } = skillAssessment
+
+      return [
+        {
+          label: qualificationType === 'English' ? 'English/Welsh' : qualificationType,
+          value: qualificationGrade,
+        },
+        {
+          label: 'Assessment Date',
+          value: readableDateFormat(assessmentDate, 'YYYY-MM-DD'),
+        },
+        {
+          label: 'Location',
+          value: establishmentName,
+        },
+      ]
+    }
+
+    const functionalSkillLevels = {
+      english: createSkillAssessmentSummary(englishSkillLevels),
+      maths: createSkillAssessmentSummary(mathsSkillLevels),
+      digiLit: createSkillAssessmentSummary(digiLitSkillLevels),
+    }
+
+    return {
+      enabled: app.esweEnabled,
+      content: functionalSkillLevels,
     }
   }
 }

--- a/backend/services/esweService.ts
+++ b/backend/services/esweService.ts
@@ -70,11 +70,11 @@ export default class EsweService {
           value: qualificationGrade,
         },
         {
-          label: 'Assessment Date',
+          label: 'Assessment date',
           value: readableDateFormat(assessmentDate, 'YYYY-MM-DD'),
         },
         {
-          label: 'Location',
+          label: 'Assessment location',
           value: establishmentName,
         },
       ]

--- a/backend/services/prisonerProfileService.js
+++ b/backend/services/prisonerProfileService.js
@@ -10,7 +10,7 @@ const {
     useOfForce: { prisons: useOfForcePrisons, ui_url: useOfForceUrl },
     complexity,
   },
-  app: { displayRetentionLink },
+  app: { displayRetentionLink, esweEnabled },
 } = require('../config')
 const logErrorAndContinue = require('../shared/logErrorAndContinue')
 
@@ -199,6 +199,7 @@ module.exports = ({
       staffId: currentUser.staffId,
       staffName: currentUser.name,
       pomStaff,
+      esweEnabled,
     }
   }
 

--- a/backend/tests/esweService.test.ts
+++ b/backend/tests/esweService.test.ts
@@ -113,18 +113,18 @@ describe('Education skills and work experience', () => {
         const expectedResult = {
           digiLit: [
             { label: 'Digital Literacy', value: 'Entry Level 2' },
-            { label: 'Assessment Date', value: '1 June 2021' },
-            { label: 'Location', value: 'HMP Winchester' },
+            { label: 'Assessment date', value: '1 June 2021' },
+            { label: 'Assessment location', value: 'HMP Winchester' },
           ],
           english: [
             { label: 'English/Welsh', value: 'Entry Level 2' },
-            { label: 'Assessment Date', value: '2 May 2021' },
-            { label: 'Location', value: 'HMP Winchester' },
+            { label: 'Assessment date', value: '2 May 2021' },
+            { label: 'Assessment location', value: 'HMP Winchester' },
           ],
           maths: [
             { label: 'Maths', value: 'Entry Level 1' },
-            { label: 'Assessment Date', value: '27 May 2021' },
-            { label: 'Location', value: 'HMP Winchester' },
+            { label: 'Assessment date', value: '27 May 2021' },
+            { label: 'Assessment location', value: 'HMP Winchester' },
           ],
         }
 
@@ -183,18 +183,18 @@ describe('Education skills and work experience', () => {
         const expectedResult = {
           digiLit: [
             { label: 'Digital Literacy', value: 'Entry Level 2' },
-            { label: 'Assessment Date', value: '1 June 2021' },
-            { label: 'Location', value: 'HMP Winchester' },
+            { label: 'Assessment date', value: '1 June 2021' },
+            { label: 'Assessment location', value: 'HMP Winchester' },
           ],
           english: [
             { label: 'English/Welsh', value: 'Entry Level 3' },
-            { label: 'Assessment Date', value: '30 June 2021' },
-            { label: 'Location', value: 'HMP Winchester' },
+            { label: 'Assessment date', value: '30 June 2021' },
+            { label: 'Assessment location', value: 'HMP Winchester' },
           ],
           maths: [
             { label: 'Maths', value: 'Entry Level 1' },
-            { label: 'Assessment Date', value: '27 May 2021' },
-            { label: 'Location', value: 'HMP Winchester' },
+            { label: 'Assessment date', value: '27 May 2021' },
+            { label: 'Assessment location', value: 'HMP Winchester' },
           ],
         }
 
@@ -234,13 +234,13 @@ describe('Education skills and work experience', () => {
         const expectedResult = {
           digiLit: [
             { label: 'Digital Literacy', value: 'Entry Level 2' },
-            { label: 'Assessment Date', value: '1 June 2021' },
-            { label: 'Location', value: 'HMP Winchester' },
+            { label: 'Assessment date', value: '1 June 2021' },
+            { label: 'Assessment location', value: 'HMP Winchester' },
           ],
           english: [
             { label: 'English/Welsh', value: 'Entry Level 2' },
-            { label: 'Assessment Date', value: '2 May 2021' },
-            { label: 'Location', value: 'HMP Winchester' },
+            { label: 'Assessment date', value: '2 May 2021' },
+            { label: 'Assessment location', value: 'HMP Winchester' },
           ],
           maths: [{ label: 'Maths', value: 'Awaiting assessment' }],
         }

--- a/backend/tests/esweService.test.ts
+++ b/backend/tests/esweService.test.ts
@@ -15,9 +15,13 @@ describe('Education skills and work experience', () => {
 
   let service
   let getLearnerProfilesMock
+  let getLearnerLatestAssessmentsMock
   beforeEach(() => {
     getLearnerProfilesMock = jest.fn()
     curiousApi.getLearnerProfiles = getLearnerProfilesMock
+    getLearnerLatestAssessmentsMock = jest.fn()
+    curiousApi.getLearnerLatestAssessments = getLearnerLatestAssessmentsMock
+
     service = EsweService.create(curiousApi)
   })
 
@@ -63,6 +67,190 @@ describe('Education skills and work experience', () => {
       expect(actual.content).toContain(fakeLearnerProfile)
       expect(getLearnerProfilesMock).toHaveBeenCalledTimes(1)
       expect(getLearnerProfilesMock).toHaveBeenCalledWith(nomisId)
+    })
+  })
+
+  describe('Work and skills tab', () => {
+    describe('functional skills assessment', () => {
+      const nomisId = 'G2823GV'
+
+      it('should return expected assessments when there is one of each subject available', async () => {
+        const dummyFunctionalSkillsLevels = {
+          prn: 'G8346GA',
+          qualifications: [
+            {
+              establishmentId: 2,
+              establishmentName: 'HMP Winchester',
+              qualification: {
+                qualificationType: 'English',
+                qualificationGrade: 'Entry Level 2',
+                assessmentDate: '2021-05-02',
+              },
+            },
+            {
+              establishmentId: 2,
+              establishmentName: 'HMP Winchester',
+              qualification: {
+                qualificationType: 'Digital Literacy',
+                qualificationGrade: 'Entry Level 2',
+                assessmentDate: '2021-06-01',
+              },
+            },
+            {
+              establishmentId: 2,
+              establishmentName: 'HMP Winchester',
+              qualification: {
+                qualificationType: 'Maths',
+                qualificationGrade: 'Entry Level 1',
+                assessmentDate: '2021-05-27',
+              },
+            },
+          ],
+        }
+
+        jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(true)
+        getLearnerLatestAssessmentsMock.mockResolvedValue([dummyFunctionalSkillsLevels])
+        const expectedResult = {
+          digiLit: [
+            { label: 'Digital Literacy', value: 'Entry Level 2' },
+            { label: 'Assessment Date', value: '1 June 2021' },
+            { label: 'Location', value: 'HMP Winchester' },
+          ],
+          english: [
+            { label: 'English/Welsh', value: 'Entry Level 2' },
+            { label: 'Assessment Date', value: '2 May 2021' },
+            { label: 'Location', value: 'HMP Winchester' },
+          ],
+          maths: [
+            { label: 'Maths', value: 'Entry Level 1' },
+            { label: 'Assessment Date', value: '27 May 2021' },
+            { label: 'Location', value: 'HMP Winchester' },
+          ],
+        }
+
+        const actual = await service.getLearnerLatestAssessments(nomisId)
+        expect(actual.enabled).toBeTruthy()
+        expect(actual.content).toStrictEqual(expectedResult)
+        expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledTimes(1)
+        expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledWith(nomisId)
+      })
+      it('should return expected assessments when there are multiple assessments for a subject available', async () => {
+        const dummyFunctionalSkillsLevels = {
+          prn: 'G8346GA',
+          qualifications: [
+            {
+              establishmentId: 2,
+              establishmentName: 'HMP Winchester',
+              qualification: {
+                qualificationType: 'English',
+                qualificationGrade: 'Entry Level 2',
+                assessmentDate: '2021-03-02',
+              },
+            },
+            {
+              establishmentId: 2,
+              establishmentName: 'HMP Winchester',
+              qualification: {
+                qualificationType: 'English',
+                qualificationGrade: 'Entry Level 3',
+                assessmentDate: '2021-06-30',
+              },
+            },
+            {
+              establishmentId: 2,
+              establishmentName: 'HMP Winchester',
+              qualification: {
+                qualificationType: 'Digital Literacy',
+                qualificationGrade: 'Entry Level 2',
+                assessmentDate: '2021-06-01',
+              },
+            },
+            {
+              establishmentId: 2,
+              establishmentName: 'HMP Winchester',
+              qualification: {
+                qualificationType: 'Maths',
+                qualificationGrade: 'Entry Level 1',
+                assessmentDate: '2021-05-27',
+              },
+            },
+          ],
+        }
+
+        jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(true)
+        getLearnerLatestAssessmentsMock.mockResolvedValue([dummyFunctionalSkillsLevels])
+
+        const expectedResult = {
+          digiLit: [
+            { label: 'Digital Literacy', value: 'Entry Level 2' },
+            { label: 'Assessment Date', value: '1 June 2021' },
+            { label: 'Location', value: 'HMP Winchester' },
+          ],
+          english: [
+            { label: 'English/Welsh', value: 'Entry Level 3' },
+            { label: 'Assessment Date', value: '30 June 2021' },
+            { label: 'Location', value: 'HMP Winchester' },
+          ],
+          maths: [
+            { label: 'Maths', value: 'Entry Level 1' },
+            { label: 'Assessment Date', value: '27 May 2021' },
+            { label: 'Location', value: 'HMP Winchester' },
+          ],
+        }
+
+        const actual = await service.getLearnerLatestAssessments(nomisId)
+        expect(actual.enabled).toBeTruthy()
+        expect(actual.content).toStrictEqual(expectedResult)
+        expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledTimes(1)
+        expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledWith(nomisId)
+      })
+      it('should return expected response when there are no assessments available for a subject', async () => {
+        const dummyFunctionalSkillsLevels = {
+          prn: 'G8346GA',
+          qualifications: [
+            {
+              establishmentId: 2,
+              establishmentName: 'HMP Winchester',
+              qualification: {
+                qualificationType: 'English',
+                qualificationGrade: 'Entry Level 2',
+                assessmentDate: '2021-05-02',
+              },
+            },
+            {
+              establishmentId: 2,
+              establishmentName: 'HMP Winchester',
+              qualification: {
+                qualificationType: 'Digital Literacy',
+                qualificationGrade: 'Entry Level 2',
+                assessmentDate: '2021-06-01',
+              },
+            },
+          ],
+        }
+
+        jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(true)
+        getLearnerLatestAssessmentsMock.mockResolvedValue([dummyFunctionalSkillsLevels])
+        const expectedResult = {
+          digiLit: [
+            { label: 'Digital Literacy', value: 'Entry Level 2' },
+            { label: 'Assessment Date', value: '1 June 2021' },
+            { label: 'Location', value: 'HMP Winchester' },
+          ],
+          english: [
+            { label: 'English/Welsh', value: 'Entry Level 2' },
+            { label: 'Assessment Date', value: '2 May 2021' },
+            { label: 'Location', value: 'HMP Winchester' },
+          ],
+          maths: [{ label: 'Maths', value: 'Awaiting assessment' }],
+        }
+
+        const actual = await service.getLearnerLatestAssessments(nomisId)
+        expect(actual.enabled).toBeTruthy()
+        expect(actual.content).toStrictEqual(expectedResult)
+        expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledTimes(1)
+        expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledWith(nomisId)
+      })
     })
   })
 })

--- a/backend/tests/prisonerProfileService.test.js
+++ b/backend/tests/prisonerProfileService.test.js
@@ -229,6 +229,7 @@ describe('prisoner profile service', () => {
         physicalCharacteristics: undefined,
         physicalMarks: undefined,
         profileInformation: undefined,
+        esweEnabled: false,
       })
 
       expect(getPrisonerProfileData).toEqual(

--- a/views/prisonerProfile/macros/prisonerSummarySection.njk
+++ b/views/prisonerProfile/macros/prisonerSummarySection.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% macro prisonerSummarySection(array = [], missingValueText = 'Not entered', attributes = {}, indentKey = false) %}
+{% macro prisonerSummarySection(array = [], missingValueText = 'Not entered', attributes = {}, indentKey = false, classes='') %}
   {% set rows = [] %}
   {% set indentClass = "govuk-summary-list__key--indent" if indentKey %}
 
@@ -26,6 +26,7 @@
   {% if rows.length %}
     {{ govukSummaryList({
       rows: rows,
+      classes: classes,
       attributes: attributes
     }) }}
   {% endif %}

--- a/views/prisonerProfile/partials/prisonerProfileTabs.njk
+++ b/views/prisonerProfile/partials/prisonerProfileTabs.njk
@@ -3,7 +3,8 @@
     { text: 'Personal', path: '/personal', visible: true, testId: 'personal' },
     { text: 'Alerts', path: '/alerts', visible: true, testId: 'alerts' },
     { text: 'Case notes', path: '/case-notes', visible: prisonerProfileData.userCanEdit, testId: 'case-notes' },
-    { text: 'Sentence and release', path: '/sentence-and-release', visible: true, testId: 'sentence-release' }
+    { text: 'Sentence and release', path: '/sentence-and-release', visible: true, testId: 'sentence-release' },
+    { text: 'Work and skills', path: '/work-and-skills', visible: prisonerProfileData.esweEnabled, testId: 'work-skills' }
   ]
 %}
 

--- a/views/prisonerProfile/prisonerWorkAndSkills/partials/learnerLatestAssessments.njk
+++ b/views/prisonerProfile/prisonerWorkAndSkills/partials/learnerLatestAssessments.njk
@@ -1,0 +1,17 @@
+{% from "../../macros/prisonerSummarySection.njk" import prisonerSummarySection %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% block prisonerProfileSection %}
+
+  {% if functionalSkillLevels %}
+      {{ prisonerSummarySection(functionalSkillLevels.maths, '', {"data-test": "maths-assessment"}, false, 'govuk-summary-list--no-border') }}
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      {{ prisonerSummarySection(functionalSkillLevels.english, '', {"data-test": "english-assessment"}, false, 'govuk-summary-list--no-border') }}
+      <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+      {{ prisonerSummarySection(functionalSkillLevels.digiLit, '', {"data-test": "digital-literacy-assessment"}, false, 'govuk-summary-list--no-border') }}
+
+  {% else %}
+    <p class="govuk-body">{{ missingLevel }}</p>
+  {% endif %}
+
+{% endblock %}

--- a/views/prisonerProfile/prisonerWorkAndSkills/prisonerWorkAndSkills.njk
+++ b/views/prisonerProfile/prisonerWorkAndSkills/prisonerWorkAndSkills.njk
@@ -1,0 +1,36 @@
+{% extends "../layouts/prisonerLayout.njk" %}
+{% from "../macros/prisonerAccordionSection.njk" import accordionSection %}
+{% from "govuk/components/accordion/macro.njk" import govukAccordion %}
+{% from "../macros/prisonerSummarySection.njk" import prisonerSummarySection %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% set title = "Work and Skills" %}
+{% set containerClasses = "prisoner-profile" %}
+{% set missingLevel = "Missing data" %}
+
+{% set functionalSkillLevels = functionalSkillLevels.content %}
+
+{% set functionalSkillsLevel %}
+  <div data-test="functional-skills-level-summary">
+    {% include "./partials/learnerLatestAssessments.njk" %}
+  </div>
+{% endset %}
+
+{% set leftSections = [
+    { heading: 'Functional skills level', html: functionalSkillsLevel }
+  ]
+%}
+
+{% block prisonerProfileSection %}
+  <div class="govuk-accordion govuk-accordion--split" data-module="govuk-accordion" id="prisoner-eswe-accordion">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {% for section in leftSections %}
+          {{ accordionSection(section.heading, section.html, loop.index) }}
+        {% endfor %}
+      </div>
+
+      <div class="govuk-grid-column-one-third"></div>
+    </div>
+  </div>
+{% endblock %} 


### PR DESCRIPTION
This PR introduces a new tab to the prisoner profile views to start to display work and skills information.

The work is behind a feature flag and uses mock data. This PR will be followed up with the curious api integration.

<img width="1084" alt="Screenshot 2021-06-29 at 11 07 27" src="https://user-images.githubusercontent.com/43253053/123781295-fa0c4180-d8cb-11eb-919f-ebf35d43d1b7.png">
