### PR TITLE
NN-3500: gets learner assessment data from the curious api

### DIFF
--- a/backend/api/curious/curiousApi.test.ts
+++ b/backend/api/curious/curiousApi.test.ts
@@ -1,5 +1,5 @@
 import nock from 'nock'
-import CuriousApi, { dummyLearnerLatestAssessments } from './curiousApi'
+import CuriousApi from './curiousApi'
 import clientFactory from '../oauthEnabledClient'
 
 const hostname = 'http://localhost:8080'
@@ -55,8 +55,14 @@ describe('curiousApi', () => {
   })
 
   describe('getLearnerLatestAssessments', () => {
+    const dummyLearnerLatestAssessments = getDummyLearnerLatestAssessments()
     it('should return the expected response data', async () => {
-      const actual = await curiousApi.getLearnerLatestAssessments('abc')
+      const nomisId = dummyLearnerLatestAssessments[0].prn
+      mock
+        .get(`/latestLearnerAssessments/${nomisId}`)
+        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .reply(200, dummyLearnerLatestAssessments)
+      const actual = await curiousApi.getLearnerLatestAssessments({ access_token: accessToken }, nomisId)
       expect(actual).toEqual(dummyLearnerLatestAssessments)
     })
   })
@@ -193,6 +199,61 @@ function getDummyEducations(): curious.LearnerEducation[] {
       fundingType: 'DPS',
       deliveryMethodType: null,
       alevelIndicator: false,
+    },
+  ]
+}
+
+function getDummyLearnerLatestAssessments(): curious.LearnerLatestAssessment[] {
+  return [
+    {
+      prn: 'G8346GA',
+      qualifications: [
+        {
+          establishmentId: 2,
+          establishmentName: 'HMP Winchester',
+          qualification: {
+            qualificationType: 'English',
+            qualificationGrade: 'Entry Level 2',
+            assessmentDate: '2021-05-02',
+          },
+        },
+        {
+          establishmentId: 2,
+          establishmentName: 'HMP Winchester',
+          qualification: {
+            qualificationType: 'English',
+            qualificationGrade: 'Entry Level 2',
+            assessmentDate: '2020-12-02',
+          },
+        },
+        {
+          establishmentId: 2,
+          establishmentName: 'HMP Winchester',
+          qualification: {
+            qualificationType: 'Digital Literacy',
+            qualificationGrade: 'Entry Level 1',
+            assessmentDate: '2020-06-01',
+          },
+        },
+        {
+          establishmentId: 2,
+          establishmentName: 'HMP Winchester',
+          qualification: {
+            qualificationType: 'Digital Literacy',
+            qualificationGrade: 'Entry Level 2',
+            assessmentDate: '2021-06-01',
+          },
+        },
+        {
+          establishmentId: 2,
+          establishmentName: 'HMP Winchester',
+          qualification: {
+            qualificationType: 'Maths',
+            qualificationGrade: 'Entry Level 2',
+            assessmentDate: '2021-06-06',
+          },
+        },
+      ],
     },
   ]
 }

--- a/backend/api/curious/curiousApi.ts
+++ b/backend/api/curious/curiousApi.ts
@@ -1,62 +1,6 @@
 import querystring from 'qs'
 import type { ClientContext, OauthApiClient } from '../oauthEnabledClient'
 
-/**
- * TODO: remove this during the curious api integration
- */
-export const dummyLearnerLatestAssessments: curious.LearnerLatestAssessment[] = [
-  {
-    prn: 'G8346GA',
-    qualifications: [
-      {
-        establishmentId: 2,
-        establishmentName: 'HMP Winchester',
-        qualification: {
-          qualificationType: 'English',
-          qualificationGrade: 'Entry Level 2',
-          assessmentDate: '2021-05-02',
-        },
-      },
-      {
-        establishmentId: 2,
-        establishmentName: 'HMP Winchester',
-        qualification: {
-          qualificationType: 'English',
-          qualificationGrade: 'Entry Level 2',
-          assessmentDate: '2020-12-02',
-        },
-      },
-      {
-        establishmentId: 2,
-        establishmentName: 'HMP Winchester',
-        qualification: {
-          qualificationType: 'Digital Literacy',
-          qualificationGrade: 'Entry Level 1',
-          assessmentDate: '2020-06-01',
-        },
-      },
-      {
-        establishmentId: 2,
-        establishmentName: 'HMP Winchester',
-        qualification: {
-          qualificationType: 'Digital Literacy',
-          qualificationGrade: 'Entry Level 2',
-          assessmentDate: '2021-06-01',
-        },
-      },
-      {
-        establishmentId: 2,
-        establishmentName: 'HMP Winchester',
-        qualification: {
-          qualificationType: 'Maths',
-          qualificationGrade: 'Entry Level 2',
-          assessmentDate: '2021-06-06',
-        },
-      },
-    ],
-  },
-]
-
 export default class CuriousApi {
   static create(client: OauthApiClient): CuriousApi {
     return new CuriousApi(client)
@@ -80,8 +24,10 @@ export default class CuriousApi {
       .then((response) => response.body)
   }
 
-  getLearnerLatestAssessments(nomisId: string): Promise<curious.LearnerLatestAssessment[]> {
-    return Promise.resolve(dummyLearnerLatestAssessments)
+  getLearnerLatestAssessments(context: ClientContext, nomisId: string): Promise<curious.LearnerLatestAssessment[]> {
+    return this.client
+      .get<curious.LearnerProfile[]>(context, `/latestLearnerAssessments/${nomisId}`)
+      .then((response) => response.body)
   }
 
   private applyQuery = (path, query?: Record<string, unknown>) =>

--- a/backend/tests/esweService.test.ts
+++ b/backend/tests/esweService.test.ts
@@ -172,8 +172,9 @@ describe('Education skills and work experience', () => {
         expect(actual.enabled).toBeTruthy()
         expect(actual.content).toStrictEqual(expectedResult)
         expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledTimes(1)
-        expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledWith(nomisId)
+        expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledWith(credentialsRef, nomisId)
       })
+
       it('should return expected assessments when there are multiple assessments for a subject available', async () => {
         const dummyFunctionalSkillsLevels = {
           prn: 'G8346GA',
@@ -242,8 +243,9 @@ describe('Education skills and work experience', () => {
         expect(actual.enabled).toBeTruthy()
         expect(actual.content).toStrictEqual(expectedResult)
         expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledTimes(1)
-        expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledWith(nomisId)
+        expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledWith(credentialsRef, nomisId)
       })
+
       it('should return expected response when there are no assessments available for a subject', async () => {
         const dummyFunctionalSkillsLevels = {
           prn: 'G8346GA',
@@ -289,7 +291,7 @@ describe('Education skills and work experience', () => {
         expect(actual.enabled).toBeTruthy()
         expect(actual.content).toStrictEqual(expectedResult)
         expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledTimes(1)
-        expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledWith(nomisId)
+        expect(getLearnerLatestAssessmentsMock).toHaveBeenCalledWith(credentialsRef, nomisId)
       })
     })
   })


### PR DESCRIPTION
This PR:
- Removes curious learner assessment mock data form the source code
- Gets offender specific learner assessment data from the curious api

<img width="1002" alt="Screenshot 2021-06-30 at 16 23 10" src="https://user-images.githubusercontent.com/43253053/123988160-b09d1e80-d9bf-11eb-9df4-16db6223bf51.png">
