### PR TITLE
NN-3426: Handle activity list timeouts better

### DIFF
--- a/backend/tests/activityListController.test.js
+++ b/backend/tests/activityListController.test.js
@@ -26,23 +26,23 @@ describe('Activity list controller', () => {
     res.status = jest.fn()
   })
   describe('Error handling', () => {
-    it('should NOT log timeout error with ECONNRESET code', async () => {
+    it('should log timeout error with ECONNRESET code', async () => {
       activityListService.getActivityList.mockRejectedValue(makeResetError())
 
       await getActivityListController(req, res)
 
-      expect(logError.mock.calls.length).toBe(0)
-      expect(res.json.mock.calls.length).toBe(0)
+      expect(logError.mock.calls.length).toBe(1)
+      expect(res.json.mock.calls.length).toBe(1)
       expect(res.end).toHaveBeenCalled()
     })
 
-    it('should NOT log timeout error with timeout in stack', async () => {
+    it('should log timeout error with timeout in stack', async () => {
       activityListService.getActivityList.mockRejectedValue(makeResetErrorWithStack())
 
       await getActivityListController(req, res)
 
-      expect(logError.mock.calls.length).toBe(0)
-      expect(res.json.mock.calls.length).toBe(0)
+      expect(logError.mock.calls.length).toBe(1)
+      expect(res.json.mock.calls.length).toBe(1)
       expect(res.end).toHaveBeenCalled()
     })
 

--- a/src/ResultsActivity/ResultsActivityContainer.js
+++ b/src/ResultsActivity/ResultsActivityContainer.js
@@ -131,6 +131,11 @@ class ResultsActivityContainer extends Component {
           timeSlot: period,
         },
       })
+      if (response?.data?.error) {
+        handleError(response.data.error)
+        setLoadedDispatch(true)
+        return
+      }
       const activityData = response.data
 
       const orderField = 'activity'


### PR DESCRIPTION
Eddie requested we give the user some indication that the request timed out - so I decided we give an obscure error message as shown below.

Secondly, I think we need to have some visibility on timeouts - surely it is important to know that things are not operating correctly, therefore I have added logging on timeout. I wasn't brave enough to report a 500 as it was deliberately removed as part of other tickets, e.g https://dsdmoj.atlassian.net/browse/NN-2878.

![image](https://user-images.githubusercontent.com/77974320/124501484-8bdae980-ddb9-11eb-8c74-3af7adb3a506.png)
