### PR TITLE
NN-3252: Cell move - confirm move page - variable 'cancel' link change

### DIFF
--- a/backend/controllers/cellMove/cellMoveUtils.js
+++ b/backend/controllers/cellMove/cellMoveUtils.js
@@ -21,6 +21,16 @@ const getBackLinkData = (referer, offenderNo) => {
   }
 }
 
+const getConfirmBackLinkData = (referer, offenderNo) => {
+  const backLink = referer || `/prisoner/${offenderNo}/cell-move/search-for-cell`
+  return {
+    backLink,
+    backLinkText: ['select-cell', 'consider-risks'].some((part) => backLink.includes(part))
+      ? 'Cancel'
+      : 'Select another cell',
+  }
+}
+
 const renderLocationOptions = (locations) => [
   { text: 'All residential units', value: 'ALL' },
   ...locations.map((location) => ({ text: location.name, value: location.key })),
@@ -42,5 +52,6 @@ module.exports = {
   getBackLinkData,
   userHasAccess,
   renderLocationOptions,
+  getConfirmBackLinkData,
   cellAttributes,
 }

--- a/backend/controllers/cellMove/confirmCellMove.js
+++ b/backend/controllers/cellMove/confirmCellMove.js
@@ -1,7 +1,7 @@
 const { raiseAnalyticsEvent } = require('../../raiseAnalyticsEvent')
 
 const { properCaseName, putLastNameFirst } = require('../../utils')
-const { getBackLinkData } = require('./cellMoveUtils')
+const { getConfirmBackLinkData } = require('./cellMoveUtils')
 
 const CSWAP = 'C-SWAP'
 
@@ -38,6 +38,7 @@ module.exports = ({ prisonApi, whereaboutsApi }) => {
 
     const cellMoveReasonRadioValues = isCellSwap ? undefined : await cellMoveReasons(res, prisonApi, reason)
 
+    const { backLink, backLinkText } = getConfirmBackLinkData(req.headers.referer, offenderNo)
     return res.render('cellMove/confirmCellMove.njk', {
       showWarning: !isCellSwap,
       offenderNo,
@@ -51,7 +52,8 @@ module.exports = ({ prisonApi, whereaboutsApi }) => {
       formValues: {
         comment,
       },
-      backLink: getBackLinkData(req.headers.referer, offenderNo).backLink,
+      backLink,
+      backLinkText,
       showCommentInput: !isCellSwap,
     })
   }

--- a/backend/tests/cellMove/confirmCellMove.test.js
+++ b/backend/tests/cellMove/confirmCellMove.test.js
@@ -73,6 +73,7 @@ describe('Change cell play back details', () => {
 
       expect(res.render).toHaveBeenCalledWith('cellMove/confirmCellMove.njk', {
         backLink: '/prisoner/A12345/cell-move/search-for-cell',
+        backLinkText: 'Select another cell',
         errors: undefined,
         formValues: {
           comment: undefined,
@@ -105,6 +106,7 @@ describe('Change cell play back details', () => {
 
       expect(res.render).toHaveBeenCalledWith('cellMove/confirmCellMove.njk', {
         backLink: '/prisoner/A12345/cell-move/search-for-cell',
+        backLinkText: 'Select another cell',
         breadcrumbPrisonerName: 'Doe, Bob',
         cellId: 'C-SWAP',
         cellMoveReasonRadioValues: undefined,
@@ -258,18 +260,27 @@ describe('Change cell play back details', () => {
       )
     })
 
-    it('sets the back link when referer data is present', async () => {
-      req.headers = { referer: `/prisoner/A12345/cell-move/select-cell` }
+    test.each`
+      referer                                         | backLinkText
+      ${'/prisoner/A12345/cell-move/select-cell'}     | ${'Cancel'}
+      ${'/prisoner/A12345/cell-move/consider-risks'}  | ${'Cancel'}
+      ${'/prisoner/A12345/cell-move/search-for-cell'} | ${'Select another cell'}
+    `(
+      'The back link button content is $backLinkText when the referer is $referer',
+      async ({ referer, backLinkText }) => {
+        req.headers = { referer }
 
-      await controller.index(req, res)
+        await controller.index(req, res)
 
-      expect(res.render).toHaveBeenCalledWith(
-        'cellMove/confirmCellMove.njk',
-        expect.objectContaining({
-          backLink: `/prisoner/A12345/cell-move/select-cell`,
-        })
-      )
-    })
+        expect(res.render).toHaveBeenCalledWith(
+          'cellMove/confirmCellMove.njk',
+          expect.objectContaining({
+            backLink: referer,
+            backLinkText,
+          })
+        )
+      }
+    )
   })
 
   describe('Post handle normal cell move', () => {

--- a/integration-tests/integration/cellMove/confirmCellMove.spec.js
+++ b/integration-tests/integration/cellMove/confirmCellMove.spec.js
@@ -79,7 +79,7 @@ context('A user can confirm the cell move', () => {
   it('should navigate back to search for cell', () => {
     const page = ConfirmCellMovePage.goTo('A12345', 1, 'Bob Doe', 'MDI-1-1')
 
-    page.backLink().contains('Cancel')
+    page.backLink().contains('Select another cell')
     page.backLink().click()
 
     cy.location('pathname').should('eq', '/prisoner/A12345/cell-move/search-for-cell')

--- a/views/cellMove/confirmCellMove.njk
+++ b/views/cellMove/confirmCellMove.njk
@@ -90,8 +90,8 @@
                 {{ govukButton({ text: "Confirm move", type: "submit" }) }}
             </form>
 
-            <p class="govuk-body govuk-!-margin-top-4">
-                <a href="{{ backLink }}" class="govuk-link" data-test="back-link">Cancel</a>
+            <p class="govuk-body">
+                <a href="{{ backLink }}" class="govuk-link" data-test="back-link">{{ backLinkText }}</a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
This PR updates the content of the back link button on the confirmCellMove view depending on what the last url to get there.

If you a simply selecting a cell then the button will say 'Cancel'. 
If you have came from searching for a sell the button will say 'Select another cell'.