### PR TITLE
Nn 3035 variable cancel link

### DIFF
--- a/backend/controllers/cellMove/cellMoveUtils.js
+++ b/backend/controllers/cellMove/cellMoveUtils.js
@@ -23,11 +23,14 @@ const getBackLinkData = (referer, offenderNo) => {
 
 const getConfirmBackLinkData = (referer, offenderNo) => {
   const backLink = referer || `/prisoner/${offenderNo}/cell-move/search-for-cell`
+
   return {
-    backLink,
-    backLinkText: ['select-cell', 'consider-risks'].some((part) => backLink.includes(part))
-      ? 'Cancel'
-      : 'Select another cell',
+    backLink: ['consider-risks', 'select-cell'].some((part) => backLink.includes(part))
+      ? `/prisoner/${offenderNo}/cell-move/select-cell`
+      : backLink,
+    backLinkText: ['consider-risks', 'select-cell'].some((part) => backLink.includes(part))
+      ? 'Select another cell'
+      : 'Cancel',
   }
 }
 

--- a/backend/tests/cellMove/confirmCellMove.test.js
+++ b/backend/tests/cellMove/confirmCellMove.test.js
@@ -73,7 +73,7 @@ describe('Change cell play back details', () => {
 
       expect(res.render).toHaveBeenCalledWith('cellMove/confirmCellMove.njk', {
         backLink: '/prisoner/A12345/cell-move/search-for-cell',
-        backLinkText: 'Select another cell',
+        backLinkText: 'Cancel',
         errors: undefined,
         formValues: {
           comment: undefined,
@@ -106,7 +106,7 @@ describe('Change cell play back details', () => {
 
       expect(res.render).toHaveBeenCalledWith('cellMove/confirmCellMove.njk', {
         backLink: '/prisoner/A12345/cell-move/search-for-cell',
-        backLinkText: 'Select another cell',
+        backLinkText: 'Cancel',
         breadcrumbPrisonerName: 'Doe, Bob',
         cellId: 'C-SWAP',
         cellMoveReasonRadioValues: undefined,
@@ -261,10 +261,11 @@ describe('Change cell play back details', () => {
     })
 
     test.each`
-      referer                                         | backLinkText
-      ${'/prisoner/A12345/cell-move/select-cell'}     | ${'Cancel'}
-      ${'/prisoner/A12345/cell-move/consider-risks'}  | ${'Cancel'}
-      ${'/prisoner/A12345/cell-move/search-for-cell'} | ${'Select another cell'}
+      referer                                                   | backLinkText
+      ${'/prisoner/A12345/cell-move/select-cell'}               | ${'Select another cell'}
+      ${'/prisoner/A12345/cell-move/consider-risks'}            | ${'Select another cell'}
+      ${'/prisoner/A12345/cell-move/search-for-cell'}           | ${'Cancel'}
+      ${'/change-someones-cell/temporary-move?keywords=A12345'} | ${'Cancel'}
     `(
       'The back link button content is $backLinkText when the referer is $referer',
       async ({ referer, backLinkText }) => {
@@ -275,7 +276,10 @@ describe('Change cell play back details', () => {
         expect(res.render).toHaveBeenCalledWith(
           'cellMove/confirmCellMove.njk',
           expect.objectContaining({
-            backLink: referer,
+            backLink:
+              referer === '/prisoner/A12345/cell-move/consider-risks'
+                ? '/prisoner/A12345/cell-move/select-cell'
+                : referer,
             backLinkText,
           })
         )

--- a/integration-tests/integration/cellMove/confirmCellMove.spec.js
+++ b/integration-tests/integration/cellMove/confirmCellMove.spec.js
@@ -31,12 +31,12 @@ context('A user can confirm the cell move', () => {
     })
     cy.task('stubCellMoveTypes', [
       {
-        code: 'ADM', 
+        code: 'ADM',
         activeFlag: 'Y',
         description: 'Administrative',
       },
       {
-        code: 'BEH', 
+        code: 'BEH',
         activeFlag: 'Y',
         description: 'Behaviour',
       },
@@ -52,18 +52,9 @@ context('A user can confirm the cell move', () => {
   it('should make a call to update an offenders cell', () => {
     const page = ConfirmCellMovePage.goTo(offenderNo, 1, 'Bob Doe', 'MDI-1-1')
     const comment = 'Hello world'
-    page
-      .form()
-      .reason()
-      .click()
-    page
-      .form()
-      .comment()
-      .type(comment)
-    page
-      .form()
-      .submitButton()
-      .click()
+    page.form().reason().click()
+    page.form().comment().type(comment)
+    page.form().submitButton().click()
 
     cy.task('verifyMoveToCell', {
       bookingId,
@@ -79,7 +70,7 @@ context('A user can confirm the cell move', () => {
   it('should navigate back to search for cell', () => {
     const page = ConfirmCellMovePage.goTo('A12345', 1, 'Bob Doe', 'MDI-1-1')
 
-    page.backLink().contains('Select another cell')
+    page.backLink().contains('Cancel')
     page.backLink().click()
 
     cy.location('pathname').should('eq', '/prisoner/A12345/cell-move/search-for-cell')
@@ -90,20 +81,11 @@ context('A user can confirm the cell move', () => {
 
     page.warning().should('not.exist')
 
-    page
-      .form()
-      .reason()
-      .should('not.exist')
+    page.form().reason().should('not.exist')
 
-    page
-      .form()
-      .comment()
-      .should('not.exist')
+    page.form().comment().should('not.exist')
 
-    page
-      .form()
-      .submitButton()
-      .click()
+    page.form().submitButton().click()
 
     cy.task('verifyMoveToCellSwap', { bookingId: 1234 }).then(assertHasRequestCount(1))
 


### PR DESCRIPTION
This PR: 
- shows 'Cancel' content on back link when going through the route prisoner profile > change cell > create space **and** Change someone’s cell > Move someone temporarily out of a cell

![scrnli_16_07_2021_15-12-10](https://user-images.githubusercontent.com/84783598/125961461-5741c096-99f1-489d-880c-77511e1e8269.png)

- shows 'Select another cell' content on back link when going through the route change cell > single occupancy/multiple occupancy 

![scrnli_16_07_2021_15-08-15](https://user-images.githubusercontent.com/84783598/125960967-2ad7baf0-33dc-4367-ae82-79e8894affbf.png)

- ‘Select another cell’ link now takes the user to 'select another cell' page
