### PR TITLE
Nn 3566 add page feature flag

### DIFF
--- a/backend/controllers/prisonerProfile/prisonerWorkAndSkills.ts
+++ b/backend/controllers/prisonerProfile/prisonerWorkAndSkills.ts
@@ -1,8 +1,13 @@
 import logErrorAndContinue from '../../shared/logErrorAndContinue'
+import { app } from '../../config'
 
 export default ({ prisonerProfileService, esweService }) =>
   async (req, res) => {
     const { offenderNo } = req.params
+
+    if (!app.esweEnabled) {
+      return res.redirect(`/prisoner/${offenderNo}`)
+    }
 
     const [prisonerProfileData, functionalSkillLevels] = await Promise.all(
       [

--- a/backend/tests/prisonerWorkAndSkills.test.ts
+++ b/backend/tests/prisonerWorkAndSkills.test.ts
@@ -1,0 +1,81 @@
+import prisonerWorkAndSkills from '../controllers/prisonerProfile/prisonerWorkAndSkills'
+import { app } from '../config'
+
+jest.mock('../config', () => ({
+  app: {
+    get esweEnabled() {
+      return false
+    },
+  },
+}))
+
+describe('Prisoner work and skills controller', () => {
+  const offenderNo = 'G3878UK'
+  const prisonerProfileData = {
+    activeAlertCount: 1,
+    agencyName: 'Moorland Closed',
+    alerts: [],
+    category: 'Cat C',
+    csra: 'High',
+    inactiveAlertCount: 2,
+    incentiveLevel: 'Standard',
+    keyWorkerLastSession: '07/04/2020',
+    keyWorkerName: 'Member, Staff',
+    location: 'CELL-123',
+    offenderName: 'Prisoner, Test',
+    offenderNo,
+  }
+  const functionalSkillLevels = {
+    digiLit: [
+      { label: 'Digital Literacy', value: 'Entry Level 1' },
+      { label: 'Assessment date', value: '1 July 2021' },
+      { label: 'Assessment location', value: 'HMP Moorland' },
+    ],
+    maths: [
+      { label: 'Maths', value: 'Entry Level 1' },
+      { label: 'Assessment date', value: '1 July 2021' },
+      { label: 'Assessment location', value: 'HMP Moorland' },
+    ],
+    english: [{ label: 'English/Welsh', value: 'Awaiting assessment' }],
+  }
+
+  const prisonerProfileService = {}
+  const esweService = {}
+
+  let req
+  let res
+  let controller
+
+  beforeEach(() => {
+    req = { params: { offenderNo }, session: { userDetails: { username: 'ITAG_USER' } } }
+    res = { locals: {}, render: jest.fn(), redirect: jest.fn() }
+    req.originalUrl = '/sentence-and-release'
+    req.get = jest.fn()
+    req.get.mockReturnValue('localhost')
+    res.status = jest.fn()
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'getPrisonerProfileData' does not exist o... Remove this comment to see the full error message
+    prisonerProfileService.getPrisonerProfileData = jest.fn().mockResolvedValue(prisonerProfileData)
+    // @ts-expect-error ts-migrate(2339) FIXME: Property 'getLatestLearningDifficulty' does not ex... Remove this comment to see the full error message
+    esweService.getLearnerLatestAssessments = jest.fn().mockResolvedValue(functionalSkillLevels)
+    controller = prisonerWorkAndSkills({
+      prisonerProfileService,
+      esweService,
+    })
+  })
+  it('should redirect to prisoner profile if esweEnabled is false', async () => {
+    jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(false)
+    await controller(req, res)
+    expect(res.render).toHaveBeenCalledTimes(0)
+  })
+  it('should make a call for the prisoner details and the latest learner assessments and render the right template', async () => {
+    jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(true)
+    await controller(req, res)
+    expect(res.render).toHaveBeenCalledWith(
+      'prisonerProfile/prisonerWorkAndSkills/prisonerWorkAndSkills.njk',
+      expect.objectContaining({
+        prisonerProfileData,
+        functionalSkillLevels,
+      })
+    )
+  })
+})


### PR DESCRIPTION
This PR:
- adds a check on the ESWE_ENABLED feature flag, which if false, redirects the user back to the prisoner profile if they go to `/work-and-skills`
- adds a couple of tests for the work and skills controller, one to test the feature flag and one to test the render