### PR TITLE
ESWE-46-add goals accordion

### DIFF
--- a/backend/api/curious/curiousApi.ts
+++ b/backend/api/curious/curiousApi.ts
@@ -30,6 +30,10 @@ export default class CuriousApi {
       .then((response) => response.body)
   }
 
+  getLearnerGoals(context: ClientContext, nomisId: string): Promise<curious.LearnerGoals> {
+    return this.client.get<curious.LearnerGoals>(context, `/learnerGoals/${nomisId}`).then((response) => response.body)
+  }
+
   private applyQuery = (path, query?: Record<string, unknown>) =>
     this.hasNonEmptyValues(query) ? `${path}?${querystring.stringify(query)}` : path
 

--- a/backend/api/curious/types/index.d.ts
+++ b/backend/api/curious/types/index.d.ts
@@ -427,4 +427,42 @@ declare namespace curious {
      */
     digiLit?: Array
   }
+
+  /**
+   *
+   * @export
+   * @interface LearnerGoals
+   */
+  export interface LearnerGoals {
+    /**
+     * NOMIS Assigned Offender Number (Prisoner Identifier)
+     * @type {string}
+     * @memberof LearnerGoals
+     */
+    prn?: string
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof LearnerGoals
+     */
+    employmentGoals?: Array
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof LearnerGoals
+     */
+    personalGoals?: Array
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof LearnerGoals
+     */
+    longTermGoals?: Array
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof LearnerGoals
+     */
+    shortTermGoals?: Array
+  }
 }

--- a/backend/controllers/prisonerProfile/prisonerWorkAndSkills.ts
+++ b/backend/controllers/prisonerProfile/prisonerWorkAndSkills.ts
@@ -9,15 +9,17 @@ export default ({ prisonerProfileService, esweService }) =>
       return res.redirect(`/prisoner/${offenderNo}`)
     }
 
-    const [prisonerProfileData, functionalSkillLevels] = await Promise.all(
+    const [prisonerProfileData, functionalSkillLevels, goals] = await Promise.all(
       [
         prisonerProfileService.getPrisonerProfileData(res.locals, offenderNo),
         esweService.getLearnerLatestAssessments(offenderNo),
+        esweService.getLearnerGoals(offenderNo),
       ].map((apiCall) => logErrorAndContinue(apiCall))
     )
 
     return res.render('prisonerProfile/prisonerWorkAndSkills/prisonerWorkAndSkills.njk', {
       prisonerProfileData,
       functionalSkillLevels,
+      goals,
     })
   }

--- a/backend/controllers/prisonerProfile/prisonerWorkAndSkills.ts
+++ b/backend/controllers/prisonerProfile/prisonerWorkAndSkills.ts
@@ -9,7 +9,7 @@ export default ({ prisonerProfileService, esweService }) =>
       return res.redirect(`/prisoner/${offenderNo}`)
     }
 
-    const [prisonerProfileData, functionalSkillLevels, goals] = await Promise.all(
+    const [prisonerProfileData, functionalSkillLevels, targets] = await Promise.all(
       [
         prisonerProfileService.getPrisonerProfileData(res.locals, offenderNo),
         esweService.getLearnerLatestAssessments(offenderNo),
@@ -20,6 +20,6 @@ export default ({ prisonerProfileService, esweService }) =>
     return res.render('prisonerProfile/prisonerWorkAndSkills/prisonerWorkAndSkills.njk', {
       prisonerProfileData,
       functionalSkillLevels,
-      goals,
+      targets,
     })
   }

--- a/backend/tests/prisonerWorkAndSkills.test.ts
+++ b/backend/tests/prisonerWorkAndSkills.test.ts
@@ -39,7 +39,7 @@ describe('Prisoner work and skills controller', () => {
     english: [{ label: 'English', value: 'Awaiting assessment' }],
   }
 
-  const goals = {
+  const targets = {
     employmentGoals: ['To be a plumber'],
     personalGoals: ['To be able to support my family'],
   }
@@ -63,7 +63,7 @@ describe('Prisoner work and skills controller', () => {
     // @ts-expect-error ts-migrate(2339) FIXME
     esweService.getLearnerLatestAssessments = jest.fn().mockResolvedValue(functionalSkillLevels)
     // @ts-expect-error ts-migrate(2339) FIXME
-    esweService.getLearnerGoals = jest.fn().mockResolvedValue(goals)
+    esweService.getLearnerGoals = jest.fn().mockResolvedValue(targets)
     controller = prisonerWorkAndSkills({
       prisonerProfileService,
       esweService,
@@ -82,7 +82,7 @@ describe('Prisoner work and skills controller', () => {
       expect.objectContaining({
         prisonerProfileData,
         functionalSkillLevels,
-        goals,
+        targets,
       })
     )
   })

--- a/backend/tests/prisonerWorkAndSkills.test.ts
+++ b/backend/tests/prisonerWorkAndSkills.test.ts
@@ -36,15 +36,12 @@ describe('Prisoner work and skills controller', () => {
       { label: 'Assessment date', value: '1 July 2021' },
       { label: 'Assessment location', value: 'HMP Moorland' },
     ],
-    english: [{ label: 'English/Welsh', value: 'Awaiting assessment' }],
+    english: [{ label: 'English', value: 'Awaiting assessment' }],
   }
 
-  const learningHistory = {
-    total: '7',
-    inProgress: '1',
-    achieved: '2',
-    failed: '1',
-    withdrawn: '3',
+  const goals = {
+    employmentGoals: ['To be a plumber'],
+    personalGoals: ['To be able to support my family'],
   }
 
   const prisonerProfileService = {}
@@ -66,7 +63,7 @@ describe('Prisoner work and skills controller', () => {
     // @ts-expect-error ts-migrate(2339) FIXME
     esweService.getLearnerLatestAssessments = jest.fn().mockResolvedValue(functionalSkillLevels)
     // @ts-expect-error ts-migrate(2339) FIXME
-    esweService.getLearnerEducation = jest.fn().mockResolvedValue(learningHistory)
+    esweService.getLearnerGoals = jest.fn().mockResolvedValue(goals)
     controller = prisonerWorkAndSkills({
       prisonerProfileService,
       esweService,
@@ -85,6 +82,7 @@ describe('Prisoner work and skills controller', () => {
       expect.objectContaining({
         prisonerProfileData,
         functionalSkillLevels,
+        goals,
       })
     )
   })

--- a/integration-tests/integration/prisonerProfile/prisonerWorkAndSkills.spec.js
+++ b/integration-tests/integration/prisonerProfile/prisonerWorkAndSkills.spec.js
@@ -35,6 +35,7 @@ context('Prisoner Work and Skills', () => {
         offenderNo,
       })
       cy.task('stubLatestLearnerAssessments500Error', {})
+      cy.task('stubLearnerGoals500Error', {})
       visitWorkAndSkillsAndExpandAccordions()
     })
 
@@ -43,9 +44,19 @@ context('Prisoner Work and Skills', () => {
         cy.get('[data-test="learner-latest-assessments-errorMessage"]').should('have.text', apiErrorText)
       })
     })
+    context('goals section', () => {
+      it('should show correct error message', () => {
+        cy.get('[data-test="goals-errorMessage"]').should('have.text', apiErrorText)
+      })
+    })
   })
 
   context('When the prisoner is not in Curious', () => {
+    const error = {
+      errorCode: 'VC404',
+      errorMessage: 'Resource not found',
+      httpStatusCode: 404,
+    }
     before(() => {
       cy.task('stubPrisonerProfileHeaderData', {
         offenderBasicDetails,
@@ -54,7 +65,8 @@ context('Prisoner Work and Skills', () => {
         caseNoteSummary: {},
         offenderNo,
       })
-      cy.task('stubLatestLearnerAssessments404Error', {})
+      cy.task('stubLatestLearnerAssessments404Error', error)
+      cy.task('stubLearnerGoals404Error', error)
       visitWorkAndSkillsAndExpandAccordions()
     })
 
@@ -69,12 +81,28 @@ context('Prisoner Work and Skills', () => {
         })
       })
     })
+    context('goals section', () => {
+      it('should show default message', () => {
+        cy.get('[data-test="goals-noGoals"]').then(($message) => {
+          cy.get($message).then(($goalsMessage) => {
+            cy.get($goalsMessage).should('have.text', 'John Smith has not set any goals')
+          })
+        })
+      })
+    })
   })
 
   context('When the user is in Curious but there is no data', () => {
     const functionalSkillsAssessments = {
       prn: 'G1670VU',
       qualifications: [],
+    }
+    const emptyGoals = {
+      prn: 'G9981UK',
+      employmentGoals: [],
+      personalGoals: [],
+      longTermGoals: [],
+      shortTermGoals: [],
     }
     before(() => {
       cy.task('stubPrisonerProfileHeaderData', {
@@ -85,6 +113,7 @@ context('Prisoner Work and Skills', () => {
         offenderNo,
       })
       cy.task('stubLatestLearnerAssessments', [functionalSkillsAssessments])
+      cy.task('stubLearnerGoals', emptyGoals)
       visitWorkAndSkillsAndExpandAccordions()
     })
 
@@ -99,6 +128,15 @@ context('Prisoner Work and Skills', () => {
               expect($summaryLabels.get(1).innerText).to.contain('Maths')
               expect($summaryLabels.get(2).innerText).to.contain('Digital Literacy')
             })
+        })
+      })
+    })
+    context('goals section', () => {
+      it('should show default message', () => {
+        cy.get('[data-test="goals-noGoals"]').then(($message) => {
+          cy.get($message).then(($goalsMessage) => {
+            cy.get($goalsMessage).should('have.text', 'John Smith has not set any goals')
+          })
         })
       })
     })
@@ -139,6 +177,17 @@ context('Prisoner Work and Skills', () => {
         ],
       },
     ]
+    const dummyGoals = {
+      prn: 'G8346GA',
+      employmentGoals: ['To be a plumber', 'To get a plumbing qualification'],
+      personalGoals: [
+        'To be able to support my family',
+        'To get a 100% attendance record on my classes',
+        'To make my mum proud',
+      ],
+      longTermGoals: ['To buy a house'],
+      shortTermGoals: ['To get out of my overdraft'],
+    }
 
     before(() => {
       cy.task('stubPrisonerProfileHeaderData', {
@@ -149,6 +198,7 @@ context('Prisoner Work and Skills', () => {
         offenderNo,
       })
       cy.task('stubLatestLearnerAssessments', functionalSkillsAssessments)
+      cy.task('stubLearnerGoals', dummyGoals)
       visitWorkAndSkillsAndExpandAccordions()
     })
 
@@ -183,6 +233,31 @@ context('Prisoner Work and Skills', () => {
               expect($summaryValues.get(6).innerText).to.contain('Level 2')
               expect($summaryValues.get(7).innerText).to.contain('19 May 2021')
               expect($summaryValues.get(8).innerText).to.contain('HMP Moorland')
+            })
+        })
+      })
+    })
+    context('goals section', () => {
+      it('should show the list of employment goals', () => {
+        cy.get('[data-test="employment-goals"]').then(($ul) => {
+          cy.get($ul)
+            .find('li')
+            .then(($listElement) => {
+              cy.get($listElement).its('length').should('eq', 2)
+              expect($listElement.get(0)).to.contain('To be a plumber')
+              expect($listElement.get(1)).to.contain('To get a plumbing qualification')
+            })
+        })
+      })
+      it('should show the list of personal goals', () => {
+        cy.get('[data-test="personal-goals"]').then(($ul) => {
+          cy.get($ul)
+            .find('li')
+            .then(($listElement) => {
+              cy.get($listElement).its('length').should('eq', 3)
+              expect($listElement.get(0)).to.contain('To be able to support my family')
+              expect($listElement.get(1)).to.contain('To get a 100% attendance record on my classes')
+              expect($listElement.get(2)).to.contain('To make my mum proud')
             })
         })
       })

--- a/integration-tests/mockApis/curiousApi.js
+++ b/integration-tests/mockApis/curiousApi.js
@@ -29,4 +29,18 @@ module.exports = {
         jsonBody: learnerHistory || [],
       },
     }),
+  stubLearnerGoals: (learnerGoals, status = 200) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/sequation-virtual-campus2-api/learnerGoals/.+?`,
+      },
+      response: {
+        status,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: learnerGoals,
+      },
+    }),
 }

--- a/integration-tests/plugins/index.js
+++ b/integration-tests/plugins/index.js
@@ -209,6 +209,10 @@ module.exports = (on) => {
     stubLatestLearnerAssessments500Error: (error) => curiousApi.stubLatestLearnerAssessments(error, 500),
     stubLatestLearnerAssessments404Error: (error) => curiousApi.stubLatestLearnerAssessments(error, 404),
 
+    stubLearnerGoals: (learnerGoals) => curiousApi.stubLearnerGoals(learnerGoals),
+    stubLearnerGoals500Error: (error) => curiousApi.stubLearnerGoals(error, 500),
+    stubLearnerGoals404Error: (error) => curiousApi.stubLearnerGoals(error, 404),
+
     stubPersonal: ({
       identifiers,
       aliases,

--- a/views/prisonerProfile/prisonerWorkAndSkills/partials/prisonerGoals.njk
+++ b/views/prisonerProfile/prisonerWorkAndSkills/partials/prisonerGoals.njk
@@ -1,0 +1,30 @@
+{% from "../../macros/prisonerSummarySection.njk" import prisonerSummarySection %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% set employmentGoals = goals.employmentGoals %}
+{% set personalGoals = goals.personalGoals %}
+{% set offenderName = (prisonerProfileData.offenderName).split(',')[1].trim() + " " +(prisonerProfileData.offenderName).split(',')[0] %}
+
+{% block prisonerProfileSection %}
+  {% if goals.employmentGoals %}
+   <h3 class="govuk-heading-s card__heading">Employment goals</h3>
+    <ul class="govuk-list" data-test="employment-goals">
+        {% for goal in employmentGoals %}
+            <li class="govuk-body govuk-!-margin-bottom-4">{{ goal }}</li>
+        {% endfor %}
+    </ul>
+
+    <h3 class="govuk-heading-s card__heading">Personal goals</h3>
+    <ul class="govuk-list" data-test="personal-goals">
+        {% for goal in personalGoals %}
+            <li class="govuk-body govuk-!-margin-bottom-4">{{ goal }}</li>
+        {% endfor %}
+    </ul>
+
+  {% elseif goals.employmentGoals === null %} 
+    <p class="govuk-body" data-test="goals-noGoals">{{ offenderName }} has not set any goals</p>
+  {% else %}
+    <p class="govuk-body" data-test="goals-errorMessage">{{ errorMessage }}</p>
+  {% endif %}
+
+{% endblock %}

--- a/views/prisonerProfile/prisonerWorkAndSkills/partials/prisonerGoals.njk
+++ b/views/prisonerProfile/prisonerWorkAndSkills/partials/prisonerGoals.njk
@@ -9,15 +9,15 @@
   {% if goals.employmentGoals %}
    <h3 class="govuk-heading-s card__heading">Employment goals</h3>
     <ul class="govuk-list" data-test="employment-goals">
-        {% for goal in employmentGoals %}
-            <li class="govuk-body govuk-!-margin-bottom-4">{{ goal }}</li>
+        {% for entry in employmentGoals %}
+            <li class="govuk-body govuk-!-margin-bottom-4">{{ entry }}</li>
         {% endfor %}
     </ul>
 
     <h3 class="govuk-heading-s card__heading">Personal goals</h3>
     <ul class="govuk-list" data-test="personal-goals">
-        {% for goal in personalGoals %}
-            <li class="govuk-body govuk-!-margin-bottom-4">{{ goal }}</li>
+        {% for entry in personalGoals %}
+            <li class="govuk-body govuk-!-margin-bottom-4">{{ entry }}</li>
         {% endfor %}
     </ul>
 

--- a/views/prisonerProfile/prisonerWorkAndSkills/prisonerWorkAndSkills.njk
+++ b/views/prisonerProfile/prisonerWorkAndSkills/prisonerWorkAndSkills.njk
@@ -9,15 +9,15 @@
 {% set errorMessage = "We cannot show these details right now. Try reloading the page." %}
 
 {% set functionalSkillLevels = functionalSkillLevels.content %}
-{% set goals = goals.content %}
+{% set goals = targets.content %}
 
-{% set functionalSkillsLevel %}
+{% set functionalSkillsLevelSection %}
   <div data-test="functional-skills-level-summary">
     {% include "./partials/learnerLatestAssessments.njk" %}
   </div>
 {% endset %}
 
-{% set goals %}
+{% set offenderGoalsSection %}
   <div data-test="goals-summary">
     {% include "./partials/prisonerGoals.njk" %}
   </div>
@@ -35,8 +35,8 @@
     { heading: 'Lorem ipsum', html: blank }
 ] %}
 {% set rightSections = [
-    { heading: 'Goals', html: goals },
-    { heading: 'Functional skills level', html: functionalSkillsLevel }
+    { heading: 'Goals', html: offenderGoalsSection },
+    { heading: 'Functional skills level', html: functionalSkillsLevelSection }
   ]
 %}
 

--- a/views/prisonerProfile/prisonerWorkAndSkills/prisonerWorkAndSkills.njk
+++ b/views/prisonerProfile/prisonerWorkAndSkills/prisonerWorkAndSkills.njk
@@ -9,10 +9,17 @@
 {% set errorMessage = "We cannot show these details right now. Try reloading the page." %}
 
 {% set functionalSkillLevels = functionalSkillLevels.content %}
+{% set goals = goals.content %}
 
 {% set functionalSkillsLevel %}
   <div data-test="functional-skills-level-summary">
     {% include "./partials/learnerLatestAssessments.njk" %}
+  </div>
+{% endset %}
+
+{% set goals %}
+  <div data-test="goals-summary">
+    {% include "./partials/prisonerGoals.njk" %}
   </div>
 {% endset %}
 
@@ -28,6 +35,7 @@
     { heading: 'Lorem ipsum', html: blank }
 ] %}
 {% set rightSections = [
+    { heading: 'Goals', html: goals },
     { heading: 'Functional skills level', html: functionalSkillsLevel }
   ]
 %}


### PR DESCRIPTION
This PR introduces the goals accordion within the work and skills tab.

Goals set example:

![scrnli_17_08_2021_15-10-59](https://user-images.githubusercontent.com/84783598/129741635-63e03ecf-7dc0-4868-ba8c-4e22c7ad9962.png)

No goals set example:

![scrnli_17_08_2021_15-12-14](https://user-images.githubusercontent.com/84783598/129741922-687a2234-e59b-4f3c-9320-2aa2aa183714.png)

user not in curious 404 example:

![scrnli_17_08_2021_15-08-17](https://user-images.githubusercontent.com/84783598/129741261-23c44f9f-d173-4782-84fc-8ab230c22f7a.png)

API error example:

![scrnli_17_08_2021_15-09-57](https://user-images.githubusercontent.com/84783598/129741453-c745e162-db82-4371-ba1b-94542f3ead6b.png)
