### PR TITLE
NN-3641: changing the client sercet from prisonapiclient to elite2api…

### DIFF
--- a/backend/config.ts
+++ b/backend/config.ts
@@ -58,7 +58,7 @@ export const apis = {
     url: process.env.OAUTH_ENDPOINT_URL || 'http://localhost:9090/auth/',
     ui_url: process.env.OAUTH_ENDPOINT_UI_URL || process.env.OAUTH_ENDPOINT_URL || 'http://localhost:9090/auth/',
     timeoutSeconds: toNumber(process.env.API_ENDPOINT_TIMEOUT_SECONDS) || 10,
-    clientId: process.env.API_CLIENT_ID || 'prisonapiclient',
+    clientId: process.env.API_CLIENT_ID || 'elite2apiclient',
     clientSecret: process.env.API_CLIENT_SECRET || 'clientsecret',
     systemClientId: process.env.API_SYSTEM_CLIENT_ID || 'prisonstaffhubclient',
     systemClientSecret: process.env.API_SYSTEM_CLIENT_SECRET || 'clientsecret',

--- a/backend/tests/sessionManagementRoutes.test.ts
+++ b/backend/tests/sessionManagementRoutes.test.ts
@@ -82,7 +82,7 @@ describe('Test the routes and middleware installed by sessionManagementRoutes', 
       .expect(302)
       .expect(
         'location',
-        'http://localhost:9090/auth/logout?client_id=prisonapiclient&redirect_uri=https://digital.prison.url/'
+        'http://localhost:9090/auth/logout?client_id=elite2apiclient&redirect_uri=https://digital.prison.url/'
       ))
 
   it('After logout get "/" should redirect to "/login"', () =>


### PR DESCRIPTION
…client to allow login against the hmpps-auth app running test data

https://dsdmoj.atlassian.net/browse/NN-3641

Change the default client id so the service will work against a locally auth-service. 

Longer term we should change to use "sigin-in" from "login" in our call backs I'll raise a ticket for this. 