### PR TITLE
ESWE-183: Remove feedback link from print

### DIFF
--- a/views/prisonerProfile/prisonerWorkAndSkills/prisonerCoursesQualificationsDetails.njk
+++ b/views/prisonerProfile/prisonerWorkAndSkills/prisonerCoursesQualificationsDetails.njk
@@ -93,7 +93,7 @@
         </p>
       </div>
     </div>
-        <div class="app-contact-panel">
+    <div class="app-contact-panel govuk-!-display-none-print">
       <h2 class="app-contact-panel__heading">This is a new page</h2>
       <p class="govuk-body app-contact-panel__body"><a class="govuk-link govuk-link--no-visited-state" target="_blank" href="https://eu.surveymonkey.com/r/BX3PPQS">Give feedback to help us improve it (opens in a new tab)</a>.
       </p>

--- a/views/prisonerProfile/prisonerWorkAndSkills/prisonerWorkInsidePrisonDetails.njk
+++ b/views/prisonerProfile/prisonerWorkAndSkills/prisonerWorkInsidePrisonDetails.njk
@@ -93,7 +93,7 @@
         </p>
       </div>
     </div>
-    <div class="app-contact-panel">
+    <div class="app-contact-panel govuk-!-display-none-print">
       <h2 class="app-contact-panel__heading">This is a new page</h2>
       <p class="govuk-body app-contact-panel__body"><a class="govuk-link govuk-link--no-visited-state" target="_blank" href="https://eu.surveymonkey.com/r/BBDMFLN">Give feedback to help us improve it (opens in a new tab)</a>.
       </p>


### PR DESCRIPTION
This PR:
- removes the ESWE feedback banner from the print version of two pages