### PR TITLE
ESWE-184: Remove the feature flag to test curious connection

### DIFF
--- a/backend/controllers/prisonerProfile/prisonerCoursesQualificationsDetails.ts
+++ b/backend/controllers/prisonerProfile/prisonerCoursesQualificationsDetails.ts
@@ -23,10 +23,6 @@ export default ({ prisonApi, esweService }) =>
   async (req, res) => {
     const { offenderNo } = req.params
 
-    if (!app.esweEnabled) {
-      return res.redirect(`/prisoner/${offenderNo}`)
-    }
-
     try {
       const [prisonerDetails, coursesAndQualifications]: [PrisonerDetails, CoursesAndQuals] = await Promise.all([
         prisonApi.getDetails(res.locals, offenderNo),

--- a/backend/controllers/prisonerProfile/prisonerWorkAndSkills.ts
+++ b/backend/controllers/prisonerProfile/prisonerWorkAndSkills.ts
@@ -5,10 +5,6 @@ export default ({ prisonerProfileService, esweService }) =>
   async (req, res) => {
     const { offenderNo } = req.params
 
-    if (!app.esweEnabled) {
-      return res.redirect(`/prisoner/${offenderNo}`)
-    }
-
     const [prisonerProfileData, functionalSkillLevels, targets, coursesAndQualifications, currentWork] =
       await Promise.all(
         [

--- a/backend/controllers/prisonerProfile/prisonerWorkInsidePrisonDetails.ts
+++ b/backend/controllers/prisonerProfile/prisonerWorkInsidePrisonDetails.ts
@@ -27,10 +27,6 @@ export default ({ paginationService, prisonApi, esweService }) =>
     const pageOffset = (pageOffsetOption && parseInt(pageOffsetOption, 10)) || 0
     const page = pageOffset / 20
 
-    if (!app.esweEnabled) {
-      return res.redirect(`/prisoner/${offenderNo}`)
-    }
-
     try {
       const [prisonerDetails, activitiesHistory]: [PrisonerDetails, activitiesInPrison] = await Promise.all([
         prisonApi.getDetails(res.locals, offenderNo),

--- a/backend/services/esweService.ts
+++ b/backend/services/esweService.ts
@@ -140,10 +140,6 @@ export default class EsweService {
   }
 
   async getLearnerProfiles(nomisId: string): Promise<LearnerProfiles> {
-    if (!app.esweEnabled) {
-      return createFlaggedContent([])
-    }
-
     let content: curious.LearnerProfile[] = null
     try {
       const context = await this.systemOauthClient.getClientCredentialsTokens()
@@ -156,10 +152,6 @@ export default class EsweService {
   }
 
   async getNeurodiversities(nomisId: string): Promise<Neurodiversities> {
-    if (!app.esweEnabled) {
-      return createFlaggedContent(null)
-    }
-
     try {
       const context = await this.systemOauthClient.getClientCredentialsTokens()
       const profiles = await this.curiousApi.getLearnerProfiles(context, nomisId)
@@ -199,10 +191,6 @@ export default class EsweService {
   }
 
   async getLearnerLatestAssessments(nomisId: string): Promise<LearnerLatestAssessments> {
-    if (!app.esweEnabled) {
-      return createFlaggedContent({})
-    }
-
     try {
       const context = await this.systemOauthClient.getClientCredentialsTokens()
       const learnerLatestAssessments = await this.curiousApi.getLearnerLatestAssessments(context, nomisId)
@@ -250,9 +238,6 @@ export default class EsweService {
   }
 
   async getLearnerGoals(nomisId: string): Promise<OffenderGoals> {
-    if (!app.esweEnabled) {
-      return createFlaggedContent(null)
-    }
     try {
       const context = await this.systemOauthClient.getClientCredentialsTokens()
       const goals = await this.curiousApi.getLearnerGoals(context, nomisId)
@@ -281,10 +266,6 @@ export default class EsweService {
   }
 
   async getLearnerEducation(nomisId: string): Promise<CurrentCoursesEnhanced> {
-    if (!app.esweEnabled) {
-      return createFlaggedContent(null)
-    }
-
     const compareByDateAsc = (a, b) =>
       compareByDate(parseDate(a.learningPlannedEndDate), parseDate(b.learningPlannedEndDate), false)
 
@@ -326,9 +307,6 @@ export default class EsweService {
   }
 
   async getLearnerEducationFullDetails(nomisId: string): Promise<LearnerEducationFullDetails> {
-    if (!app.esweEnabled) {
-      return createFlaggedContent(null)
-    }
     try {
       const context = await this.systemOauthClient.getClientCredentialsTokens()
       const courses = await this.curiousApi.getLearnerEducation(context, nomisId)
@@ -377,10 +355,6 @@ export default class EsweService {
   }
 
   async getCurrentActivities(nomisId: string): Promise<CurrentWork> {
-    if (!app.esweEnabled) {
-      return createFlaggedContent(null)
-    }
-
     try {
       const context = await this.systemOauthClient.getClientCredentialsTokens()
       const prisonerDetails = await this.prisonApi.getPrisonerDetails(context, nomisId)
@@ -416,10 +390,6 @@ export default class EsweService {
   }
 
   async getActivitiesHistoryDetails(nomisId: string, page: number): Promise<activitiesHistory> {
-    if (!app.esweEnabled) {
-      return createFlaggedContent(null)
-    }
-
     try {
       const sort = 'endDate,desc'
       const context = await this.systemOauthClient.getClientCredentialsTokens()

--- a/backend/tests/esweService.test.ts
+++ b/backend/tests/esweService.test.ts
@@ -65,14 +65,6 @@ describe('Education skills and work experience', () => {
   describe('learner profiles', () => {
     const nomisId = 'G2823GV'
 
-    it('should return expected learner profiles', async () => {
-      const actual = await service.getLearnerProfiles(nomisId)
-      expect(actual.enabled).toBeFalsy()
-      expect(actual.content).toHaveLength(0)
-      expect(getLearnerProfilesMock).not.toHaveBeenCalled()
-      expect(systemOauthClient.getClientCredentialsTokens).not.toHaveBeenCalled()
-    })
-
     it('should set enabled to true', async () => {
       jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(true)
 
@@ -98,16 +90,6 @@ describe('Education skills and work experience', () => {
 
   describe('Learning difficulties', () => {
     const nomisId = 'G8930UW'
-
-    it('should return null content when feature flag is disabled', async () => {
-      jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(false)
-      const actual = await service.getNeurodiversities(nomisId)
-      expect(actual.enabled).toBeFalsy()
-      expect(actual.content).toBeNull()
-      expect(getLearnerProfilesMock).not.toHaveBeenCalled()
-      expect(getLearnerEducationMock).not.toHaveBeenCalled()
-      expect(systemOauthClient.getClientCredentialsTokens).not.toHaveBeenCalled()
-    })
 
     it('should return null content on error', async () => {
       jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(true)
@@ -223,15 +205,6 @@ describe('Education skills and work experience', () => {
   describe('Courses and qualifications details', () => {
     const nomisId = 'G8930UW'
 
-    it('should return null content when feature flag is disabled', async () => {
-      jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(false)
-      const actual = await service.getLearnerEducationFullDetails(nomisId)
-      expect(actual.enabled).toBeFalsy()
-      expect(actual.content).toBeNull()
-      expect(getLearnerEducationMock).not.toHaveBeenCalled()
-      expect(systemOauthClient.getClientCredentialsTokens).not.toHaveBeenCalled()
-    })
-
     it('should return null content on error', async () => {
       jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(true)
       getLearnerEducationMock.mockRejectedValue(new Error('error'))
@@ -321,15 +294,6 @@ describe('Education skills and work experience', () => {
 
   describe('Work inside prison details', () => {
     const nomisId = 'G8930UW'
-
-    it('should return null content when feature flag is disabled', async () => {
-      jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(false)
-      const actual = await service.getActivitiesHistoryDetails(nomisId)
-      expect(actual.enabled).toBeFalsy()
-      expect(actual.content).toBeNull()
-      expect(getLearnerActivitiesHistoryMock).not.toHaveBeenCalled()
-      expect(systemOauthClient.getClientCredentialsTokens).not.toHaveBeenCalled()
-    })
     it('should return null content on error', async () => {
       jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(true)
       getLearnerActivitiesHistoryMock.mockRejectedValue(new Error('error'))
@@ -540,14 +504,6 @@ describe('Education skills and work experience', () => {
     })
     describe('Goals', () => {
       const nomisId = 'G3609VL'
-      it('should return null when feature flag is disabled', async () => {
-        jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(false)
-        const actual = await service.getLearnerGoals(nomisId)
-        expect(actual.enabled).toBeFalsy()
-        expect(actual.content).toBeNull()
-        expect(getLearnerGoalsMock).not.toHaveBeenCalled()
-        expect(systemOauthClient.getClientCredentialsTokens).not.toHaveBeenCalled()
-      })
       it('should return null content on error', async () => {
         jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(true)
         getLearnerGoalsMock.mockRejectedValue(new Error('error'))
@@ -609,14 +565,6 @@ describe('Education skills and work experience', () => {
     })
     describe('Courses and qualifications', () => {
       const nomisId = 'G3609VL'
-      it('should return null when feature flag is disabled', async () => {
-        jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(false)
-        const actual = await service.getLearnerEducation(nomisId)
-        expect(actual.enabled).toBeFalsy()
-        expect(actual.content).toBeNull()
-        expect(getLearnerEducationMock).not.toHaveBeenCalled()
-        expect(systemOauthClient.getClientCredentialsTokens).not.toHaveBeenCalled()
-      })
       it('should return null content on error', async () => {
         jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(true)
         getLearnerEducationMock.mockRejectedValue(new Error('error'))
@@ -720,15 +668,6 @@ describe('Education skills and work experience', () => {
     })
     describe('Work inside prison', () => {
       const nomisId = 'G3609VL'
-      it('should return null when feature flag is disabled', async () => {
-        jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(false)
-        const actual = await service.getCurrentActivities(nomisId)
-        expect(actual.enabled).toBeFalsy()
-        expect(actual.content).toBeNull()
-        expect(getLearnerEducationMock).not.toHaveBeenCalled()
-        expect(getPrisonerDetailsMock).not.toHaveBeenCalled()
-        expect(systemOauthClient.getClientCredentialsTokens).not.toHaveBeenCalled()
-      })
       it('should return null content on work history api error', async () => {
         jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(true)
         getLearnerActivitiesHistoryMock.mockRejectedValue(new Error('error'))

--- a/backend/tests/prisonerCoursesQualificationsDetails.test.ts
+++ b/backend/tests/prisonerCoursesQualificationsDetails.test.ts
@@ -98,11 +98,6 @@ describe('Prisoner courses and qualifications details controller', () => {
       esweService,
     })
   })
-  it('should redirect to prisoner profile if esweEnabled is false', async () => {
-    jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(false)
-    await controller(req, res)
-    expect(res.render).toHaveBeenCalledTimes(0)
-  })
   it('should make expected calls and render the right template', async () => {
     const prisonerName = 'Apoustius Ignian'
     const breadcrumbPrisonerName = 'Ignian, Apoustius'

--- a/backend/tests/prisonerWorkAndSkills.test.ts
+++ b/backend/tests/prisonerWorkAndSkills.test.ts
@@ -83,11 +83,6 @@ describe('Prisoner work and skills controller', () => {
       esweService,
     })
   })
-  it('should redirect to prisoner profile if esweEnabled is false', async () => {
-    jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(false)
-    await controller(req, res)
-    expect(res.render).toHaveBeenCalledTimes(0)
-  })
   it('should make expected calls and render the right template', async () => {
     jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(true)
     await controller(req, res)

--- a/backend/tests/prisonerWorkInsidePrisonDetails.test.ts
+++ b/backend/tests/prisonerWorkInsidePrisonDetails.test.ts
@@ -57,11 +57,6 @@ describe('Prisoner work inside prison details controller', () => {
       esweService,
     })
   })
-  it('should redirect to prisoner profile if esweEnabled is false', async () => {
-    jest.spyOn(app, 'esweEnabled', 'get').mockReturnValue(false)
-    await controller(req, res)
-    expect(res.render).toHaveBeenCalledTimes(0)
-  })
   it('should make expected calls and render the right template', async () => {
     const prisonerName = 'Apoustius Ignian'
     const breadcrumbPrisonerName = 'Ignian, Apoustius'


### PR DESCRIPTION
This PR:
- Removes the ESWE_ENABLED feature flag on the controllers for /work-and-skills, /work-activities and /courses-qualifications
- Removes the feature flag on each of the functions within the EsweService file
- Removes tests related to the feature flag

**The feature flag is still set to false** so that the 'work and skills 'tab on the prisoner profile is invisible, and also the neurodiversity part of the 'personal' tab is hidden. This will be dealt with if this stage goes well and the connection to the production Curious API works
