### PR TITLE
BAVL-553 excluding video link court hearing appointment types from bulk appointment bookings. Court hearing video appointments should be managed by BVLS only.

### DIFF
--- a/backend/utils.test.ts
+++ b/backend/utils.test.ts
@@ -25,6 +25,7 @@ import {
   properCaseName,
   putLastNameFirst,
   stringWithAbbreviationsProcessor,
+  filterNot,
 } from './utils'
 
 class TestError extends Error {
@@ -550,5 +551,29 @@ describe('compareNumbers', () => {
   })
   it('should sort with undefined being equal', () => {
     expect(compareNumbers(undefined, undefined)).toEqual(0)
+  })
+})
+
+describe('filterNot', () => {
+  const values = [{ code: 'A' }, { code: 'B' }, { code: 'C' }]
+
+  it('should exclude A from object array', () => {
+    expect(filterNot(values, 'code', ['A'])).toEqual([{ code: 'B' }, { code: 'C' }])
+  })
+
+  it('should exclude B from object array', () => {
+    expect(filterNot(values, 'code', ['B'])).toEqual([{ code: 'A' }, { code: 'C' }])
+  })
+
+  it('should exclude C from object array', () => {
+    expect(filterNot(values, 'code', ['C'])).toEqual([{ code: 'A' }, { code: 'B' }])
+  })
+
+  it('should exclude A and B from object array', () => {
+    expect(filterNot(values, 'code', ['A', 'B'])).toEqual([{ code: 'C' }])
+  })
+
+  it('should exclude nothing when no match in object array', () => {
+    expect(filterNot(values, 'code', ['X'])).toEqual([{ code: 'A' }, { code: 'B' }, { code: 'C' }])
   })
 })

--- a/backend/utils.ts
+++ b/backend/utils.ts
@@ -348,6 +348,9 @@ export const isRedirectCaseLoad = (activeCaseLoadId: string): boolean => {
   return !config.app.prisonerProfileRedirect.exemptions?.split(',')?.includes(activeCaseLoadId)
 }
 
+export const filterNot = (array: any[], key: string, neq: unknown[]) =>
+  array.filter((object) => !neq.includes(object[key]))
+
 export default {
   isBeforeToday,
   isToday,
@@ -399,4 +402,5 @@ export default {
   getWith404AsNull,
   stringWithAbbreviationsProcessor,
   isRedirectCaseLoad,
+  filterNot,
 }

--- a/backend/utils/nunjucksSetup.ts
+++ b/backend/utils/nunjucksSetup.ts
@@ -11,6 +11,7 @@ import {
   hyphenatedStringToCamel,
   possessive,
   formatTimestampToDate,
+  filterNot,
 } from '../utils'
 import config from '../config'
 
@@ -187,6 +188,8 @@ export default (app: express.Express, conf: typeof config) => {
     const array = fullName.split(' ')
     return `${array[0][0]}. ${array.reverse()[0]}`
   })
+
+  njkEnv.addFilter('filterNot', filterNot)
 
   return njkEnv
 }

--- a/views/bulkAppointmentsAddDetails.njk
+++ b/views/bulkAppointmentsAddDetails.njk
@@ -101,7 +101,7 @@
                         label: {
                             text: "Appointment type"
                         },
-                        items: appointmentTypes | addDefaultSelectedVale('Select') | setSelected(appointmentType),
+                        items: appointmentTypes | filterNot('value', ['VLB', 'VLPM']) | addDefaultSelectedVale('Select') | setSelected(appointmentType),
                         errorMessage: errors | findError('appointment-type')
                     }) }}
 


### PR DESCRIPTION
During the decommissioning of the legacy BVLS code, a gap was noticed where you can bulk book court hearing video links entirely bypassing the BVLS service (old and new versions).  These go straight into NOMIS and BVLS has no knowledge of these appointments.

Note, as part of this change I have also excluded probation meetings as the same applies for these also.

This should not be allowed.  All of these appointment types should go through the BVLS service.